### PR TITLE
[Refactor] MapReduce integrationTests cleanup

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/OpenSearchFixturePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/OpenSearchFixturePlugin.groovy
@@ -73,7 +73,7 @@ class OpenSearchFixturePlugin implements Plugin<Project> {
         def clustersContainer = project.extensions.getByName(TestClustersPlugin.EXTENSION_NAME) as NamedDomainObjectContainer<OpenSearchCluster>
         def integTestCluster = clustersContainer.create("integTest") { OpenSearchCluster cluster ->
             cluster.version = version
-            cluster.testDistribution = TestDistribution.INTEG_TEST
+            cluster.testDistribution = TestDistribution.ARCHIVE
         }
 
         integrationTests.all { StandaloneRestIntegTestTask integrationTest ->
@@ -91,10 +91,8 @@ class OpenSearchFixturePlugin implements Plugin<Project> {
             integTestCluster.setting("http.host", "localhost")
             integTestCluster.systemProperty('opensearch.http.cname_in_publish_address', 'true')
         } else if (majorVersion >= 2) {
-            integTestCluster.setting("node.roles", "[\"master\", \"data\", \"ingest\"]")
+            integTestCluster.setting("node.roles", "[\"cluster_manager\", \"data\", \"ingest\"]")
             integTestCluster.setting("http.host", "localhost")
-            // TODO: Remove this when this is the default in 7
-            integTestCluster.systemProperty('opensearch.http.cname_in_publish_address', 'true')
         }
 
         // Also write a script to a file for use in tests

--- a/mr/src/itest/java/org/opensearch/hadoop/integration/mr/AbstractMRNewApiSaveTest.java
+++ b/mr/src/itest/java/org/opensearch/hadoop/integration/mr/AbstractMRNewApiSaveTest.java
@@ -201,6 +201,22 @@ public class AbstractMRNewApiSaveTest {
         assertFalse("job should have failed", runJob(conf));
     }
 
+    @Test
+    public void testSaveWithIngest() throws Exception {
+        Configuration conf = createConf();
+
+        RestUtils.ExtendedRestClient client = new RestUtils.ExtendedRestClient();
+        String prefix = "mrnewapi";
+        String pipeline = "{\"description\":\"Test Pipeline\",\"processors\":[{\"set\":{\"field\":\"pipeTEST\",\"value\":true,\"override\":true}}]}";
+        client.put("/_ingest/pipeline/" + prefix + "-pipeline", StringUtils.toUTF(pipeline));
+        client.close();
+
+        conf.set(ConfigurationOptions.OPENSEARCH_RESOURCE, resource("mrnewapi-ingested", "data", clusterInfo.getMajorVersion()));
+        conf.set(ConfigurationOptions.ES_INGEST_PIPELINE, "mrnewapi-pipeline");
+        conf.set(ConfigurationOptions.OPENSEARCH_NODES_INGEST_ONLY, "true");
+
+        runJob(conf);
+    }
     @Test(expected = OpenSearchHadoopIllegalArgumentException.class)
     public void testUpdateWithoutId() throws Exception {
         Configuration conf = createConf();

--- a/mr/src/itest/java/org/opensearch/hadoop/rest/commonshttp/auth/spnego/AbstractSpnegoAuthSchemeTest.java
+++ b/mr/src/itest/java/org/opensearch/hadoop/rest/commonshttp/auth/spnego/AbstractSpnegoAuthSchemeTest.java
@@ -238,7 +238,7 @@ public class AbstractSpnegoAuthSchemeTest {
                 method.setHeaders(new Header[]{new Header("WWW-Authenticate", "Negotiate")});
                 method.setURI(new org.opensearch.hadoop.thirdparty.apache.commons.httpclient.URI("http", null, "127.0.0.1", 9200));
 
-                Credentials credentials = new SpnegoCredentials(HadoopUserProvider.create(new TestSettings()), "HTTP/_HOST@BUILD.ELASTIC.CO");
+                Credentials credentials = new SpnegoCredentials(HadoopUserProvider.create(new TestSettings()), "HTTP/_HOST@BUILD.CI.OPENSEARCH.ORG");
 
                 // Parse Challenge
                 Map challenges = AuthChallengeParser.parseChallenges(method.getResponseHeaders("WWW-Authenticate"));

--- a/mr/src/itest/java/org/opensearch/hadoop/rest/commonshttp/auth/spnego/AbstractSpnegoNegotiatorTest.java
+++ b/mr/src/itest/java/org/opensearch/hadoop/rest/commonshttp/auth/spnego/AbstractSpnegoNegotiatorTest.java
@@ -346,6 +346,6 @@ public class AbstractSpnegoNegotiatorTest {
     }
 
     private static String withRealm(String principal) {
-        return principal + "@BUILD.ELASTIC.CO";
+        return principal + "@BUILD.CI.OPENSEARCH.ORG";
     }
 }

--- a/mr/src/test/java/org/opensearch/hadoop/security/JdkUserTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/security/JdkUserTest.java
@@ -120,7 +120,7 @@ public class JdkUserTest {
 
         assertThat(jdkUser.getKerberosPrincipal(), is(nullValue()));
 
-        KerberosPrincipal principal = new KerberosPrincipal("username@BUILD.ELASTIC.CO");
+        KerberosPrincipal principal = new KerberosPrincipal("username@BUILD.CI.OPENSEARCH.ORG");
         subject.getPrincipals().add(principal);
 
         assertThat(jdkUser.getKerberosPrincipal(), is(equalTo(principal)));

--- a/test/fixtures/minikdc/src/main/java/org/opensearch/hadoop/test/fixture/minikdc/MiniKdcFixture.java
+++ b/test/fixtures/minikdc/src/main/java/org/opensearch/hadoop/test/fixture/minikdc/MiniKdcFixture.java
@@ -95,8 +95,8 @@ public class MiniKdcFixture {
         kdcConf.setProperty(MiniKdc.INSTANCE, "DefaultKrbServer");
         kdcConf.setProperty(MiniKdc.TRANSPORT, "TCP");
         // ES-Hadoop Project Specific Defaults
-        kdcConf.setProperty(MiniKdc.ORG_NAME, "BUILD.ELASTIC"); // used to make REALM
-        kdcConf.setProperty(MiniKdc.ORG_DOMAIN, "CO"); // used to make REALM
+        kdcConf.setProperty(MiniKdc.ORG_NAME, "BUILD.CI.OPENSEARCH"); // used to make REALM
+        kdcConf.setProperty(MiniKdc.ORG_DOMAIN, "ORG"); // used to make REALM
 
         // Parse Fixture Properties in one pass
         Enumeration<Object> sysProps = System.getProperties().keys();

--- a/test/shared/src/main/java/org/opensearch/hadoop/fixtures/KDCFixture.java
+++ b/test/shared/src/main/java/org/opensearch/hadoop/fixtures/KDCFixture.java
@@ -54,8 +54,8 @@ public class KDCFixture extends ExternalResource {
     @Override
     protected void before() throws Throwable {
         Properties conf = MiniKdc.createConf();
-        conf.setProperty(MiniKdc.ORG_NAME, "BUILD.ELASTIC");
-        conf.setProperty(MiniKdc.ORG_DOMAIN, "CO");
+        conf.setProperty(MiniKdc.ORG_NAME, "BUILD.CI.OPENSEARCH");
+        conf.setProperty(MiniKdc.ORG_DOMAIN, "ORG");
         kdc = new MiniKdc(conf, temporaryFolder.newFolder());
         kdc.start();
 


### PR DESCRIPTION
Refactors from MapReduce integration tests from legacy to opensearch namespace and integTest servers. Uses ARCHIVE instead of INTEG_TEST since INTEG_TEST does not bundle all modules.
