### PR TITLE
[Test] Fix MR unit test failures

### DIFF
--- a/mr/src/main/java/org/opensearch/hadoop/rest/Resource.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/Resource.java
@@ -91,7 +91,6 @@ public class Resource {
         int slash = res.indexOf("/");
         boolean typeExists = slash >= 0;
 
-        OpenSearchMajorVersion opensearchMajorVersion = settings.getInternalVersionOrThrow();
         // Types can no longer the specified at all! Index names only!
         if (typeExists) {
             throw new OpenSearchHadoopIllegalArgumentException(String.format(

--- a/mr/src/main/java/org/opensearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/RestClient.java
@@ -708,6 +708,11 @@ public class RestClient implements Closeable, StatsAware {
             throw new OpenSearchHadoopIllegalStateException("Unable to retrieve OpenSearch version.");
         }
         String versionNumber = versionBody.get("number");
+        OpenSearchMajorVersion major = OpenSearchMajorVersion.parse(versionNumber);
+        if (major.before(OpenSearchMajorVersion.V_2_X)) {
+            throw new OpenSearchHadoopIllegalStateException("Invalid major version [" + major + "]. " +
+                    "Version is lower than minimum required version [" + OpenSearchMajorVersion.V_2_X + "].");
+        }
         return new ClusterInfo(new ClusterName(clusterName, clusterUUID), OpenSearchMajorVersion.parse(versionNumber));
     }
 

--- a/mr/src/main/java/org/opensearch/hadoop/util/OpenSearchMajorVersion.java
+++ b/mr/src/main/java/org/opensearch/hadoop/util/OpenSearchMajorVersion.java
@@ -76,6 +76,12 @@ public class OpenSearchMajorVersion implements Serializable {
     }
 
     public static OpenSearchMajorVersion parse(String version) {
+        if (version.startsWith("0.")) {
+            return new OpenSearchMajorVersion((byte) 0, version);
+        }
+        if (version.startsWith("1.")) {
+            return new OpenSearchMajorVersion((byte) 1, version);
+        }
         if (version.startsWith("2.")) {
             return new OpenSearchMajorVersion((byte) 2, version);
         }

--- a/mr/src/test/java/org/opensearch/hadoop/rest/QueryTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/rest/QueryTest.java
@@ -48,13 +48,6 @@ public class QueryTest {
     }
 
     @Test
-    public void testSimpleQuery() {
-        cfg.setResourceRead("foo/bar");
-        Resource typed = new Resource(cfg, true);
-        assertTrue(builder.resource(typed).toString().contains("foo/bar"));
-    }
-
-    @Test
     public void testSimpleQueryTypeless() {
         cfg.setInternalVersion(OpenSearchMajorVersion.LATEST);
         cfg.setResourceRead("foo");

--- a/mr/src/test/java/org/opensearch/hadoop/rest/bulk/BulkProcessorTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/rest/bulk/BulkProcessorTest.java
@@ -101,7 +101,7 @@ public class BulkProcessorTest {
         inputEntry = IOUtils.asString(getClass().getResourceAsStream("/org/opensearch/hadoop/rest/bulk-retry-input-template.json"));
 
         testSettings = new TestSettings();
-        testSettings.setResourceWrite("foo/bar");
+        testSettings.setResourceWrite("foo");
         testSettings.setInternalClusterInfo(esClusterInfo);
         testSettings.setProperty(ConfigurationOptions.OPENSEARCH_BATCH_SIZE_ENTRIES, "10");
         testSettings.setProperty(ConfigurationOptions.ES_BATCH_WRITE_RETRY_WAIT, "1ms");

--- a/mr/src/test/java/org/opensearch/hadoop/serialization/CommandTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/serialization/CommandTest.java
@@ -221,7 +221,7 @@ public class CommandTest {
         assumeFalse(isDeleteOP() && jsonInput);
         assumeFalse(ConfigurationOptions.ES_OPERATION_UPSERT.equals(operation));
         Settings settings = settings();
-        if (version.onOrAfter(OpenSearchMajorVersion.V_3_X)) {
+        if (version.onOrAfter(OpenSearchMajorVersion.V_2_X)) {
             settings.setResourceWrite("{n}");
         } else {
             settings.setResourceWrite("foo/{n}");
@@ -229,7 +229,7 @@ public class CommandTest {
 
         create(settings).write(data).copyTo(ba);
         String header;
-        if (version.onOrAfter(OpenSearchMajorVersion.V_3_X)) {
+        if (version.onOrAfter(OpenSearchMajorVersion.V_2_X)) {
             header = "{\"_index\":\"1\"" + (isUpdateOp() ? ",\"_id\":2" : "") + "}";
         } else {
             header = "{\"_index\":\"foo\",\"_type\":\"1\"" + (isUpdateOp() ? ",\"_id\":2" : "") + "}";
@@ -360,7 +360,7 @@ public class CommandTest {
         if (version.onOrAfter(OpenSearchMajorVersion.V_3_X)) {
             set.setResourceWrite("foo");
         } else {
-            set.setResourceWrite("foo/bar");
+            set.setResourceWrite("foo");
         }
         if (isUpdateOp()) {
             set.setProperty(ConfigurationOptions.ES_MAPPING_ID, "<2>");

--- a/mr/src/test/java/org/opensearch/hadoop/serialization/dto/NodeInfoTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/serialization/dto/NodeInfoTest.java
@@ -42,12 +42,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class NodeInfoTest {
-    @Test
-    public void testV1() throws Exception {
-        Map<String, NodeInfo> nodeMap = testNodeInfo(getClass().getResourceAsStream("client-nodes-v1.json"));
-        assertFalse(nodeMap.get("Darkhawk").isIngest());
-        assertFalse(nodeMap.get("Unseen").isIngest());
-    }
 
     @Test
     public void testV2() throws Exception {

--- a/mr/src/test/java/org/opensearch/hadoop/serialization/field/DefaultIndexExtractorTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/serialization/field/DefaultIndexExtractorTest.java
@@ -56,7 +56,7 @@ public class DefaultIndexExtractorTest {
     @Test
     public void createFieldExtractor() {
         Settings settings = new TestSettings();
-        settings.setResourceWrite("test");
+        settings.setResourceWrite("{field}");
         settings.setInternalVersion(OpenSearchMajorVersion.V_3_X);
         InitializationUtils.setFieldExtractorIfNotSet(settings, MapFieldExtractor.class, LOG);
 
@@ -69,13 +69,13 @@ public class DefaultIndexExtractorTest {
         data.put("field", "data");
 
         Object field = iformat.field(data);
-        assertThat(field.toString(), equalTo("\"_index\":\"test\""));
+        assertThat(field.toString(), equalTo("\"_index\":\"data\""));
     }
 
     @Test(expected = OpenSearchHadoopIllegalArgumentException.class)
     public void createFieldExtractorNull() {
         Settings settings = new TestSettings();
-        settings.setResourceWrite("test");
+        settings.setResourceWrite("test/{field}");
         settings.setInternalVersion(OpenSearchMajorVersion.V_3_X);
         InitializationUtils.setFieldExtractorIfNotSet(settings, MapFieldExtractor.class, LOG);
 

--- a/mr/src/test/java/org/opensearch/hadoop/serialization/field/DefaultIndexExtractorTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/serialization/field/DefaultIndexExtractorTest.java
@@ -56,8 +56,8 @@ public class DefaultIndexExtractorTest {
     @Test
     public void createFieldExtractor() {
         Settings settings = new TestSettings();
-        settings.setResourceWrite("test/{field}");
-        settings.setInternalVersion(OpenSearchMajorVersion.V_2_X);
+        settings.setResourceWrite("test");
+        settings.setInternalVersion(OpenSearchMajorVersion.V_3_X);
         InitializationUtils.setFieldExtractorIfNotSet(settings, MapFieldExtractor.class, LOG);
 
         IndexExtractor iformat = ObjectUtils.instantiate(settings.getMappingIndexExtractorClassName(), settings);
@@ -69,14 +69,14 @@ public class DefaultIndexExtractorTest {
         data.put("field", "data");
 
         Object field = iformat.field(data);
-        assertThat(field.toString(), equalTo("\"_index\":\"test\",\"_type\":\"data\""));
+        assertThat(field.toString(), equalTo("\"_index\":\"test\""));
     }
 
     @Test(expected = OpenSearchHadoopIllegalArgumentException.class)
     public void createFieldExtractorNull() {
         Settings settings = new TestSettings();
-        settings.setResourceWrite("test/{field}");
-        settings.setInternalVersion(OpenSearchMajorVersion.V_2_X);
+        settings.setResourceWrite("test");
+        settings.setInternalVersion(OpenSearchMajorVersion.V_3_X);
         InitializationUtils.setFieldExtractorIfNotSet(settings, MapFieldExtractor.class, LOG);
 
         IndexExtractor iformat = ObjectUtils.instantiate(settings.getMappingIndexExtractorClassName(), settings);

--- a/mr/src/test/java/org/opensearch/hadoop/serialization/field/JsonFieldExtractorsTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/serialization/field/JsonFieldExtractorsTest.java
@@ -42,23 +42,6 @@ import static org.junit.Assert.*;
 
 public class JsonFieldExtractorsTest {
 
-    @Test
-    public void indexAndType() {
-        Settings settings = new TestSettings();
-        // Types will not be supported in 8.x
-        settings.setInternalVersion(OpenSearchMajorVersion.V_2_X);
-        settings.setResourceWrite("test/{field}");
-        JsonFieldExtractors jsonFieldExtractors = new JsonFieldExtractors(settings);
-
-        String data = "{\"field\":\"data\"}";
-        BytesArray bytes = new BytesArray(data);
-
-        jsonFieldExtractors.process(bytes);
-
-        assertThat(jsonFieldExtractors.indexAndType().hasPattern(), is(true));
-        assertThat(jsonFieldExtractors.indexAndType().field(data).toString(), equalTo("\"_index\":\"test\",\"_type\":\"data\""));
-    }
-
     @Test(expected = OpenSearchHadoopIllegalArgumentException.class)
     public void indexAndTypeNull() {
         Settings settings = new TestSettings();

--- a/mr/src/test/resources/org/opensearch/hadoop/serialization/dto/client-nodes-v1.json
+++ b/mr/src/test/resources/org/opensearch/hadoop/serialization/dto/client-nodes-v1.json
@@ -1,6 +1,6 @@
 {
     "ok" : true,
-    "cluster_name" : "elasticsearch",
+    "cluster_name" : "opensearch",
     "nodes" : {
         "fiR5azTbTDiX59m78yzOTw" : {
             "name" : "Darkhawk",

--- a/mr/src/test/resources/org/opensearch/hadoop/serialization/dto/client-nodes-v2.json
+++ b/mr/src/test/resources/org/opensearch/hadoop/serialization/dto/client-nodes-v2.json
@@ -1,6 +1,6 @@
 {
     "ok" : true,
-    "cluster_name" : "elasticsearch",
+    "cluster_name" : "opensearch",
     "nodes" : {
         "fiR5azTbTDiX59m78yzOTw" : {
             "name" : "Darkhawk",
@@ -22,7 +22,7 @@
             "name" : "Unseen",
             "transport_address" : "inet[/192.168.1.50:9301]",
             "host" : "cerberus",
-            "version" : "2.3.3",
+            "version" : "3.3.3",
             "http_address" : "inet[/192.168.1.50:9201]",
             "http" : {
                 "bound_address" : "inet[/0:0:0:0:0:0:0:0%0:9201]",

--- a/mr/src/test/resources/org/opensearch/hadoop/serialization/dto/client-nodes-v2.json
+++ b/mr/src/test/resources/org/opensearch/hadoop/serialization/dto/client-nodes-v2.json
@@ -7,10 +7,7 @@
             "transport_address" : "inet[/192.168.1.50:9300]",
             "host" : "cerberus",
             "version" : "2.3.3",
-            "attributes" : {
-                "data" : "false",
-                "master" : "false"
-            },
+            "roles" : [],
             "http" : {
                 "bound_address" : "inet[/0:0:0:0:0:0:0:0:9200]",
                 "publish_address" : "inet[/192.168.1.50:9200]",
@@ -23,6 +20,10 @@
             "transport_address" : "inet[/192.168.1.50:9301]",
             "host" : "cerberus",
             "version" : "3.3.3",
+            "roles" : [
+                "master",
+                "data"
+            ],
             "http_address" : "inet[/192.168.1.50:9201]",
             "http" : {
                 "bound_address" : "inet[/0:0:0:0:0:0:0:0%0:9201]",

--- a/mr/src/test/resources/org/opensearch/hadoop/serialization/dto/client-nodes-v5.json
+++ b/mr/src/test/resources/org/opensearch/hadoop/serialization/dto/client-nodes-v5.json
@@ -1,12 +1,12 @@
 {
     "ok" : true,
-    "cluster_name" : "elasticsearch",
+    "cluster_name" : "opensearch",
     "nodes" : {
         "fiR5azTbTDiX59m78yzOTw" : {
             "name" : "Darkhawk",
             "transport_address" : "192.168.1.50:9300",
             "host" : "cerberus",
-            "version" : "5.0.0-alpha5",
+            "version" : "3.0.0-alpha5",
             "roles" : [],
             "http" : {
                 "bound_address" : "0:0:0:0:0:0:0:0:9200",
@@ -19,7 +19,7 @@
             "name" : "Unseen",
             "transport_address" : "192.168.1.50:9301",
             "host" : "cerberus",
-            "version" : "5.0.0-alpha5",
+            "version" : "3.0.0-alpha5",
             "roles" : [
                 "master",
                 "data",


### PR DESCRIPTION
Fixes unit test failures in MapReduce module due to type removal and other legacy version features that are not available in OpenSearch.
