### PR TITLE
[Refactor] more es and legacy references to OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note that os-hadoop supports both the so-called 'old' and the 'new' API through 
 ### 'Old' (`org.apache.hadoop.mapred`) API
 
 ### Reading
-To read data from Os, configure the `OpenSearchInputFormat` on your job configuration along with the relevant [properties](#configuration-properties):
+To read data from OpenSearch, configure the `OpenSearchInputFormat` on your job configuration along with the relevant [properties](#configuration-properties):
 ```java
 JobConf conf = new JobConf();
 conf.setInputFormat(OpenSearchInputFormat.class);
@@ -164,9 +164,9 @@ REGISTER /path_to_jar/opensearch-hadoop-<version>.jar;
 ```
 Additionally one can define an alias to save some chars:
 ```
-%define ESSTORAGE org.opensearch.pig.hadoop.OpenSearchStorage()
+%define OPENSEARCHSTORAGE org.opensearch.pig.hadoop.OpenSearchStorage()
 ```
-and use `$ESSTORAGE` for storage definition.
+and use `$OPENSEARCHSTORAGE` for storage definition.
 
 ### Reading
 To read data from OpenSearch, use `OpenSearchStorage` and specify the query through the `LOAD` function:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The properties are read mainly from the Hadoop configuration but the user can sp
 
 ### Required
 ```
-opensearch.resource=<ES resource location, relative to the host/port specified above>
+opensearch.resource=<OpenSearch resource location, relative to the host/port specified above>
 ```
 ### Essential
 ```
@@ -113,14 +113,14 @@ job.waitForCompletion(true);
 ```
 
 ## [Apache Hive][]
-OpenSearch-Hadoop provides a Hive storage handler for OpenSearch, meaning one can define an [external table][] on top of ES.
+OpenSearch-Hadoop provides a Hive storage handler for OpenSearch, meaning one can define an [external table][] on top of OpenSearch.
 
 Add opensearch-hadoop-<version>.jar to `hive.aux.jars.path` or register it manually in your Hive script (recommended):
 ```
 ADD JAR /path_to_jar/opensearch-hadoop-<version>.jar;
 ```
 ### Reading
-To read data from ES, define a table backed by the desired index:
+To read data from OpenSearch, define a table backed by the desired index:
 ```SQL
 CREATE EXTERNAL TABLE artists (
     id      BIGINT,
@@ -169,7 +169,7 @@ Additionally one can define an alias to save some chars:
 and use `$ESSTORAGE` for storage definition.
 
 ### Reading
-To read data from ES, use `OpenSearchStorage` and specify the query through the `LOAD` function:
+To read data from OpenSearch, use `OpenSearchStorage` and specify the query through the `LOAD` function:
 ```SQL
 A = LOAD 'radio/artists' USING org.opensearch.pig.hadoop.OpenSearchStorage('opensearch.query=?q=me*');
 DUMP A;
@@ -196,7 +196,7 @@ import org.opensearch.spark._
 ..
 val conf = ...
 val sc = new SparkContext(conf)
-sc.esRDD("radio/artists", "?q=me*")
+sc.opensearchRDD("radio/artists", "?q=me*")
 ```
 
 #### Spark SQL
@@ -222,7 +222,7 @@ val sc = new SparkContext(conf)
 val numbers = Map("one" -> 1, "two" -> 2, "three" -> 3)
 val airports = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
 
-sc.makeRDD(Seq(numbers, airports)).saveToEs("spark/docs")
+sc.makeRDD(Seq(numbers, airports)).saveToOpenSearch("spark/docs")
 ```
 
 #### Spark SQL
@@ -231,7 +231,7 @@ sc.makeRDD(Seq(numbers, airports)).saveToEs("spark/docs")
 import org.opensearch.spark.sql._
 
 val df = sqlContext.read.json("examples/people.json")
-df.saveToEs("spark/people")
+df.saveToOpenSearch("spark/people")
 ```
 
 ### Java
@@ -239,7 +239,7 @@ df.saveToEs("spark/people")
 In a Java environment, use the `org.opensearch.spark.rdd.java.api` package, in particular the `JavaOpenSearchSpark` class.
 
 ### Reading
-To read data from ES, create a dedicated `RDD` and specify the query as an argument.
+To read data from OpenSearch, create a dedicated `RDD` and specify the query as an argument.
 
 ```java
 import org.apache.spark.api.java.JavaSparkContext;
@@ -248,7 +248,7 @@ import org.opensearch.spark.rdd.api.java.JavaOpenSearchSpark;
 SparkConf conf = ...
 JavaSparkContext jsc = new JavaSparkContext(conf);
 
-JavaPairRDD<String, Map<String, Object>> esRDD = JavaOpenSearchSpark.esRDD(jsc, "radio/artists");
+JavaPairRDD<String, Map<String, Object>> opensearchRDD = JavaOpenSearchSpark.opensearchRDD(jsc, "radio/artists");
 ```
 
 #### Spark SQL
@@ -272,7 +272,7 @@ Map<String, ?> numbers = ImmutableMap.of("one", 1, "two", 2);
 Map<String, ?> airports = ImmutableMap.of("OTP", "Otopeni", "SFO", "San Fran");
 
 JavaRDD<Map<String, ?>> javaRDD = jsc.parallelize(ImmutableList.of(numbers, airports));
-JavaOpenSearchSpark.saveToEs(javaRDD, "spark/docs");
+JavaOpenSearchSpark.saveToOpenSearch(javaRDD, "spark/docs");
 ```
 
 #### Spark SQL
@@ -281,14 +281,14 @@ JavaOpenSearchSpark.saveToEs(javaRDD, "spark/docs");
 import org.opensearch.spark.sql.api.java.JavaOpenSearchSparkSQL;
 
 DataFrame df = sqlContext.read.json("examples/people.json")
-JavaOpenSearchSparkSQL.saveToEs(df, "spark/docs")
+JavaOpenSearchSparkSQL.saveToOpenSearch(df, "spark/docs")
 ```
 
 ## [Apache Storm][]
 OpenSearch-Hadoop provides native integration with Storm: for reading a dedicated `Spout` and for writing a specialized `Bolt`
 
 ### Reading
-To read data from ES, use `OpenSearchSpout`:
+To read data from OpenSearch, use `OpenSearchSpout`:
 ```java
 import org.opensearch.storm.OpenSearchSpout;
 
@@ -298,7 +298,7 @@ builder.setBolt("bolt", new PrinterBolt()).shuffleGrouping("opensearch-spout");
 ```
 
 ### Writing
-To index data to ES, use `OpenSearchBolt`:
+To index data to OpenSearch, use `OpenSearchBolt`:
 
 ```java
 import org.opensearch.storm.OpenSearchBolt;

--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/buildtools/AntFixture.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/buildtools/AntFixture.groovy
@@ -219,7 +219,7 @@ class AntFixture extends AntTask implements Fixture {
         logger.error("  failure marker exists: ${failureMarker.exists()}")
         logger.error("  pid file exists: ${pidFile.exists()}")
         logger.error("  ports file exists: ${portsFile.exists()}")
-        // also dump the log file for the startup script (which will include ES logging output to stdout)
+        // also dump the log file for the startup script (which will include OpenSearch logging output to stdout)
         if (runLog.exists()) {
             logger.error("\n  [log]")
             runLog.eachLine { line -> logger.error("    ${line}") }

--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/HadoopClusterFormationTasks.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/HadoopClusterFormationTasks.groovy
@@ -316,7 +316,7 @@ class HadoopClusterFormationTasks {
 
     static Task configureCheckPreviousTask(String name, Project project, Task setup, InstanceInfo node) {
         // TODO - This is a later item for CI stability
-        // This is here for the moment to keep parity with the ES fixture
+        // This is here for the moment to keep parity with the OpenSearch fixture
         return setup
     }
 
@@ -358,7 +358,7 @@ class HadoopClusterFormationTasks {
     static Task configureExtraConfigFilesTask(String name, Project project, Task setup, InstanceInfo node) {
         // TODO: Extra Config Files
         // We don't really need them at the moment, but might in the future.
-        // This is just here to keep parity with the ES fixture
+        // This is just here to keep parity with the OpenSearch fixture
         return setup
     }
 
@@ -549,7 +549,7 @@ class HadoopClusterFormationTasks {
         // the waitfor failed, so dump any output we got (if info logging this goes directly to stdout)
         logger.error("|\n|  [ant output]")
         instance.buffer.toString('UTF-8').eachLine { line -> logger.error("|    ${line}") }
-        // also dump the log file for the startup script (which will include ES logging output to stdout)
+        // also dump the log file for the startup script (which will include OpenSearch logging output to stdout)
         if (instance.startLog.exists()) {
             logger.error("|\n|  [log]")
             instance.startLog.eachLine { line -> logger.error("|    ${line}") }

--- a/buildSrc/src/main/java/org/opensearch/hadoop/gradle/buildtools/DependenciesInfoTask.java
+++ b/buildSrc/src/main/java/org/opensearch/hadoop/gradle/buildtools/DependenciesInfoTask.java
@@ -188,7 +188,7 @@ public class DependenciesInfoTask extends ConventionTask {
      * <li><em>UNKNOWN</em> if LICENSE file is not present for this dependency.</li>
      * <li><em>one SPDX identifier</em> if the LICENSE content matches with an SPDX license.</li>
      * <li><em>Custom;URL</em> if it's not an SPDX license,
-     * URL is the Github URL to the LICENSE file in elasticsearch repository.</li>
+     * URL is the Github URL to the LICENSE file in opensearch repository.</li>
      * </ul>
      *
      * @param group dependency group

--- a/buildSrc/src/main/java/org/opensearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
+++ b/buildSrc/src/main/java/org/opensearch/hadoop/gradle/buildtools/info/GlobalBuildInfoPlugin.java
@@ -71,7 +71,7 @@ import java.util.stream.Stream;
 
 public class GlobalBuildInfoPlugin implements Plugin<Project> {
     private static final Logger LOGGER = Logging.getLogger(GlobalBuildInfoPlugin.class);
-    private static final String DEFAULT_VERSION_JAVA_FILE_PATH = "server/src/main/java/org/elasticsearch/Version.java";
+    private static final String DEFAULT_VERSION_JAVA_FILE_PATH = "server/src/main/java/org/opensearch/Version.java";
     private static Integer _defaultParallel = null;
 
     private final JavaInstallationRegistry javaInstallationRegistry;

--- a/buildSrc/src/main/java/org/opensearch/hadoop/gradle/buildtools/package-info.java
+++ b/buildSrc/src/main/java/org/opensearch/hadoop/gradle/buildtools/package-info.java
@@ -29,12 +29,12 @@
 
 /**
  * All classes in org.opensearch.hadoop.gradle.buildtools are originally
- * copied from the elasticsearch build-tools project. These classes are
+ * copied from the opensearch build-tools project. These classes are
  * considered internal in build tools and will not be supported by the build tools
  * team and also not being published in upcoming build tool releases.
  * This will make it easier to build tools team to move forward and distinct explicitly
  * between internal and shared and published build logic to be used by external
- * elasticsearch plugins.
+ * opensearch plugins.
  *
  * We'll revisit these classes here and adjust as the dedicated public build tools plugins
  * evolve over time.

--- a/buildSrc/src/main/java/org/opensearch/hadoop/gradle/util/Resources.java
+++ b/buildSrc/src/main/java/org/opensearch/hadoop/gradle/util/Resources.java
@@ -40,7 +40,7 @@ public class Resources {
 
     /**
      * Duplicated from org.opensearch.hadoop.gradle.buildtools.info.GlobalBuildInfoPlugin#getResourceContents(java.lang.String)
-     * Needed in BuildPlugin for reading ES-Hadoop specific minimum runtime and compile versions
+     * Needed in BuildPlugin for reading OpenSearch-Hadoop specific minimum runtime and compile versions
      * @param resourcePath the classpath resource to load
      * @return The contents of the resource file
      */

--- a/hive/src/itest/resources/log4j2.properties
+++ b/hive/src/itest/resources/log4j2.properties
@@ -24,7 +24,7 @@ logger.Hive-ExecMapper.level=warn
 #logger.Hive-HiveQL-Exec-Package.name=org.apache.hadoop.hive.ql.exec
 #logger.Hive-HiveQL-Exec-Package.level=warn
 
-# ES-Hadoop logging
+# OpenSearch-Hadoop logging
 logger.Hive-HiveMetaStore.name=org.apache.hadoop.hive.metastore.HiveMetaStore
 logger.Hive-HiveMetaStore.level=warn
 #logger.OpenSearch-Hadoop-Package.name=org.opensearch.hadoop

--- a/hive/src/main/java/org/opensearch/hadoop/hive/HiveUtils.java
+++ b/hive/src/main/java/org/opensearch/hadoop/hive/HiveUtils.java
@@ -86,10 +86,10 @@ abstract class HiveUtils {
     }
 
     /**
-     * Renders the full collection of field names needed from ES by combining the names of
+     * Renders the full collection of field names needed from OpenSearch by combining the names of
      * the hive table fields with the user provided name mappings.
      * @param settings Settings to pull hive column names and user name mappings from.
-     * @return A collection of ES field names
+     * @return A collection of OpenSearch field names
      */
     static Collection<String> columnToAlias(Settings settings) {
         FieldAlias fa = alias(settings);
@@ -115,7 +115,7 @@ abstract class HiveUtils {
      * Reads the current aliases, and then the set of hive column names. Remaps the raw hive column names (_col1, _col2)
      * to the names used in the hive table, or, if the mappings exist, the names in the mappings instead.
      * @param settings Settings to pull user name mappings and hive column names from
-     * @return FieldAlias mapping object to go from hive column name to ES field name
+     * @return FieldAlias mapping object to go from hive column name to OpenSearch field name
      */
     static FieldAlias alias(Settings settings) {
         Map<String, String> aliasMap = SettingsUtils.aliases(settings.getProperty(HiveConstants.MAPPING_NAMES), true);

--- a/mr/src/main/java/org/opensearch/hadoop/cfg/HadoopSettingsManager.java
+++ b/mr/src/main/java/org/opensearch/hadoop/cfg/HadoopSettingsManager.java
@@ -35,7 +35,7 @@ import org.opensearch.hadoop.OpenSearchHadoopIllegalArgumentException;
 
 /**
  * Factory for loading settings based on various configuration objects, such as Properties or Hadoop configuration.
- * The factory main role is to minimize the number of dependencies required at compilation time in the event that ES-Hadoop is running
+ * The factory main role is to minimize the number of dependencies required at compilation time in the event that OpenSearch-Hadoop is running
  * in a non-Hadoop oriented environment.
  */
 public class HadoopSettingsManager implements SettingsManager<Object> {

--- a/mr/src/main/java/org/opensearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/opensearch/hadoop/cfg/Settings.java
@@ -72,7 +72,7 @@ public abstract class Settings {
      * @return The {@link OpenSearchMajorVersion} extracted from the properties or {@link OpenSearchMajorVersion#LATEST} if not present
      * @deprecated This is kind of a dangerous method to use, because it assumes that you care about which version you are working with,
      *             but the version you receive from this call may not be accurate, and thus, cannot be trusted to let you make accurate
-     *             decisions about the version of ES you are speaking with. Prefer to use the {@link Settings#getInternalVersionOrThrow()}
+     *             decisions about the version of OpenSearch you are speaking with. Prefer to use the {@link Settings#getInternalVersionOrThrow()}
      *             instead.
      */
     @Deprecated

--- a/mr/src/main/java/org/opensearch/hadoop/mr/OpenSearchMapReduceUtil.java
+++ b/mr/src/main/java/org/opensearch/hadoop/mr/OpenSearchMapReduceUtil.java
@@ -75,7 +75,7 @@ public final class OpenSearchMapReduceUtil {
             ClusterInfo clusterInfo = settings.getClusterInfoOrNull();
             RestClient bootstrap = new RestClient(settings);
             try {
-                // first get ES main action info if it's missing
+                // first get OpenSearch main action info if it's missing
                 if (clusterInfo == null) {
                     clusterInfo = bootstrap.mainInfo();
                 }
@@ -110,7 +110,7 @@ public final class OpenSearchMapReduceUtil {
             ClusterInfo clusterInfo = settings.getClusterInfoOrNull();
             RestClient bootstrap = new RestClient(settings);
             try {
-                // first get ES main action info if it's missing
+                // first get OpenSearch main action info if it's missing
                 if (clusterInfo == null) {
                     clusterInfo = bootstrap.mainInfo();
                 }

--- a/mr/src/main/java/org/opensearch/hadoop/mr/security/TokenUtil.java
+++ b/mr/src/main/java/org/opensearch/hadoop/mr/security/TokenUtil.java
@@ -72,7 +72,7 @@ public class TokenUtil {
      * context for the life of the operation.
      * @param client The OpenSearch client
      * @param user the user object that contains credentials for obtaining an auth token
-     * @return the authentication token in ES-Hadoop specific format.
+     * @return the authentication token in OpenSearch-Hadoop specific format.
      */
     private static OpenSearchToken obtainOpenSearchToken(final RestClient client, User user) {
         // TODO: Should we extend this to basic authentication at some point?
@@ -217,7 +217,7 @@ public class TokenUtil {
     }
 
     /**
-     * Get the authentication token of the user for the provided cluster name in its ES-Hadoop specific form.
+     * Get the authentication token of the user for the provided cluster name in its OpenSearch-Hadoop specific form.
      * @return null if the user does not have the token, otherwise the auth token for the cluster.
      */
     private static OpenSearchToken getOpenSearchAuthToken(ClusterName clusterName, User user) {

--- a/mr/src/main/java/org/opensearch/hadoop/rest/InitializationUtils.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/InitializationUtils.java
@@ -352,7 +352,7 @@ public abstract class InitializationUtils {
     public static ClusterInfo discoverAndValidateClusterInfo(Settings settings, Log log) {
         ClusterInfo mainInfo;
         RestClient bootstrap = new RestClient(settings);
-        // first get ES main action info
+        // first get OpenSearch main action info
         try {
             mainInfo = bootstrap.mainInfo();
             if (log.isDebugEnabled()) {

--- a/mr/src/main/java/org/opensearch/hadoop/rest/PartitionDefinition.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/PartitionDefinition.java
@@ -43,7 +43,7 @@ import java.util.Arrays;
 import static org.opensearch.hadoop.util.StringUtils.EMPTY_ARRAY;
 
 /**
- * Represents a logical split of an elasticsearch query.
+ * Represents a logical split of an opensearch query.
  */
 public class PartitionDefinition implements Serializable, Comparable<PartitionDefinition> {
     private final String index;

--- a/mr/src/main/java/org/opensearch/hadoop/rest/Resource.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/Resource.java
@@ -86,7 +86,7 @@ public class Resource {
         String res = StringUtils.sanitizeResource(resource);
 
         // 3) Resource must contain an index, but may not necessarily contain a type.
-        // This is dependent on the version of ES we are talking with.
+        // This is dependent on the version of OpenSearch we are talking with.
         int slash = res.indexOf("/");
         boolean typeExists = slash >= 0;
 

--- a/mr/src/main/java/org/opensearch/hadoop/rest/RestClient.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/RestClient.java
@@ -483,7 +483,7 @@ public class RestClient implements Closeable, StatsAware {
         try {
             BytesArray body = new BytesArray("{\"scroll_id\":\"" + scrollId + "\"}");
             // use post instead of get to avoid some weird encoding issues (caused by the long URL)
-            // do not retry the request on another node, because that can lead to ES returning a error or
+            // do not retry the request on another node, because that can lead to OpenSearch returning a error or
             // less data being returned than requested.  See: https://github.com/elastic/elasticsearch-hadoop/issues/1302
             InputStream is = execute(POST, "_search/scroll?scroll=" + scrollKeepAlive.toString(), body, true, false).body();
             stats.scrollTotal++;

--- a/mr/src/main/java/org/opensearch/hadoop/rest/SimpleHttpRetryPolicy.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/SimpleHttpRetryPolicy.java
@@ -43,7 +43,7 @@ public class SimpleHttpRetryPolicy implements HttpRetryPolicy, SettingsAware {
             }
 
             switch (httpStatus) {
-            // ES is busy, allow retries
+            // OpenSearch is busy, allow retries
             case HttpStatus.TOO_MANY_REQUESTS:
             case HttpStatus.SERVICE_UNAVAILABLE:
                 return true;

--- a/mr/src/main/java/org/opensearch/hadoop/rest/bulk/BulkProcessor.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/bulk/BulkProcessor.java
@@ -220,7 +220,7 @@ public class BulkProcessor implements Closeable, StatsAware {
                     // Log messages, and if wait time is set, perform the thread sleep.
                     initFlushOperation(bulkLoggingID, retryOperation, retries.size(), waitTime);
 
-                    // Exec bulk operation to ES, get response.
+                    // Exec bulk operation to OpenSearch, get response.
                     debugLog(bulkLoggingID, "Submitting request");
                     RestClient.BulkActionResponse bar = restClient.bulk(resource, data);
                     debugLog(bulkLoggingID, "Response received");

--- a/mr/src/main/java/org/opensearch/hadoop/security/JdkUserProvider.java
+++ b/mr/src/main/java/org/opensearch/hadoop/security/JdkUserProvider.java
@@ -37,7 +37,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * Operates by retrieving the currently set subject in a way that ES-Hadoop understands, or
+ * Operates by retrieving the currently set subject in a way that OpenSearch-Hadoop understands, or
  * a blank subject if there isn't currently one available.
  */
 public class JdkUserProvider extends UserProvider {

--- a/mr/src/main/java/org/opensearch/hadoop/serialization/ScrollReader.java
+++ b/mr/src/main/java/org/opensearch/hadoop/serialization/ScrollReader.java
@@ -62,7 +62,7 @@ import org.opensearch.hadoop.util.IOUtils;
 import org.opensearch.hadoop.util.StringUtils;
 
 /**
- * Class handling the conversion of data from ES to target objects. It performs tree navigation tied to a potential ES mapping (if available).
+ * Class handling the conversion of data from OpenSearch to target objects. It performs tree navigation tied to a potential OpenSearch mapping (if available).
  * Expected to read a _search response.
  */
 public class ScrollReader implements Closeable {

--- a/mr/src/main/java/org/opensearch/hadoop/serialization/dto/mapping/FieldParser.java
+++ b/mr/src/main/java/org/opensearch/hadoop/serialization/dto/mapping/FieldParser.java
@@ -89,7 +89,7 @@ public final class FieldParser {
         Map<String, Object> mappingEntries = (Map<String, Object>) mappingsObject.get("mappings");
 
         // Iterate over the mappings to collect their names and contents
-        // In versions of ES that have a single type system, there will either
+        // In versions of OpenSearch that have a single type system, there will either
         // be a single named mapping or a single unnamed mapping returned.
         if (includeTypeName) {
             // Every entry within mappingEntries is a type name mapped to the actual mappings

--- a/mr/src/main/java/org/opensearch/hadoop/util/FastByteArrayOutputStream.java
+++ b/mr/src/main/java/org/opensearch/hadoop/util/FastByteArrayOutputStream.java
@@ -81,7 +81,7 @@ public class FastByteArrayOutputStream extends OutputStream {
      * Creates a new byte array output stream. The buffer capacity is
      * initially 1024 bytes, though its size increases if necessary.
      * <p/>
-     * ES: We use 1024 bytes since we mainly use this to build json/smile
+     * OpenSearch: We use 1024 bytes since we mainly use this to build json/smile
      * content in memory, and rarely does the 32 byte default in ByteArrayOutputStream fits...
      */
     public FastByteArrayOutputStream() {

--- a/mr/src/test/resources/log4j2.properties
+++ b/mr/src/test/resources/log4j2.properties
@@ -24,7 +24,7 @@ logger.Hive-RetryingHMSHandler.level=fatal
 logger.Hive-HiveQL-Exec-Package.name=org.apache.hadoop.hive.ql.exec
 logger.Hive-HiveQL-Exec-Package.level=warn
 
-# ES-Hadoop logging
+# OpenSearch-Hadoop logging
 logger.Hive-HiveMetaStore.name=org.apache.hadoop.hive.metastore.HiveMetaStore
 logger.Hive-HiveMetaStore.level=warn
 logger.OpenSearch-Hadoop-Pig-Package.name=org.opensearch.hadoop.pig
@@ -49,8 +49,8 @@ logger.OpenSearch-Hadoop-Pig-Package.level=info
 #logger.HTTPConnections.level=trace
 
 # Integration testing
-logger.ES-Hive-IntegrationTests.name=org.opensearch.hadoop.integration.hive
-logger.ES-Hive-IntegrationTests.level=info
+logger.OpenSearch-Hive-IntegrationTests.name=org.opensearch.hadoop.integration.hive
+logger.OpenSearch-Hive-IntegrationTests.level=info
 
 # Pig
 #logger.Pig.name=org.apache.pig
@@ -64,11 +64,11 @@ logger.Spark-ShortName.name=spark
 logger.Spark-ShortName.level=warn
 #logger.Spark-SparkContext.name=org.apache.spark.SparkContext
 #logger.Spark-SparkContext.level=info
-#logger.ES-Spark.name=org.opensearch.spark
-#logger.ES-Spark.level=trace
+#logger.OpenSearch-Spark.name=org.opensearch.spark
+#logger.OpenSearch-Spark.level=trace
 # SparkSQL
-#logger.ES-Spark-DataSource.name=org.opensearch.spark.sql.DataSource
-#logger.ES-Spark-DataSource.level=trace
+#logger.OpenSearch-Spark-DataSource.name=org.opensearch.spark.sql.DataSource
+#logger.OpenSearch-Spark-DataSource.level=trace
 
 # Storm
 # shut up ZK
@@ -76,5 +76,5 @@ logger.Zookeeper.name=org.apache.zookeeper
 logger.Zookeeper.level=warn
 logger.Storm-Shaded.name=org.apache.storm.shade
 logger.Storm-Shaded.level=warn
-#logger.ES-Storm.name=org.opensearch.integration.storm
-#logger.ES-Storm.level=trace
+#logger.OpenSearch-Storm.name=org.opensearch.integration.storm
+#logger.OpenSearch-Storm.level=trace

--- a/mr/src/test/resources/org/opensearch/hadoop/rest/node-list.json
+++ b/mr/src/test/resources/org/opensearch/hadoop/rest/node-list.json
@@ -1,5 +1,5 @@
 {
-  "cluster_name": "elasticsearch",
+  "cluster_name": "opensearch",
   "nodes": {
     "MMkGcn1EQk6myfNvTgpUrg": {
       "name": "node1",

--- a/pig/src/itest/resources/log4j2.properties
+++ b/pig/src/itest/resources/log4j2.properties
@@ -8,7 +8,7 @@ appender.console.name=stdout
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %m%n
 
-# ES-Hadoop logging
+# OpenSearch-Hadoop logging
 logger.OpenSearch-Hadoop-Pig-Package.name=org.opensearch.hadoop.pig
 logger.OpenSearch-Hadoop-Pig-Package.level=info
 #logger.OpenSearch-Hadoop-Package.name=org.opensearch.hadoop

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -28,7 +28,7 @@
  */
 
 subprojects {
-    // Apply root build plugin to grab ES versions at the very least
+    // Apply root build plugin to grab OpenSearch versions at the very least
     apply plugin: 'opensearch.hadoop.build'
 
     // QA projects will not have distributions to speak of.

--- a/qa/kerberos/build.gradle
+++ b/qa/kerberos/build.gradle
@@ -457,7 +457,7 @@ if (disableTests) {
     // Map Reduce Jobs
     // =============================================================================
     
-    // Run the MR job to load data to ES. Ensure Kerberos settings are available.
+    // Run the MR job to load data to OpenSearch. Ensure Kerberos settings are available.
     HadoopMRJob mrLoadData = config.createClusterTask('mrLoadData', HadoopMRJob.class) {
         clusterConfiguration = config
         useCluster(testClusters.integTest)
@@ -484,7 +484,7 @@ if (disableTests) {
     }
     integrationTest.dependsOn(mrLoadData)
     
-    // Run the MR job to read data out of ES. Ensure Kerberos settings are available.
+    // Run the MR job to read data out of OpenSearch. Ensure Kerberos settings are available.
     HadoopMRJob mrReadData = config.createClusterTask('mrReadData', HadoopMRJob.class) {
         clusterConfiguration = config
         useCluster(testClusters.integTest)
@@ -514,7 +514,7 @@ if (disableTests) {
     // Spark Jobs
     // =============================================================================
 
-    // Run the Spark job to load data to ES. Ensure Kerberos settings are available.
+    // Run the Spark job to load data to OpenSearch. Ensure Kerberos settings are available.
     SparkApp sparkLoadData = config.createClusterTask('sparkLoadData', SparkApp.class) {
         clusterConfiguration = config
         useCluster(testClusters.integTest)
@@ -546,7 +546,7 @@ if (disableTests) {
     }
     integrationTest.dependsOn(sparkLoadData)
     
-    // Run the Spark job to load data to ES. Ensure Kerberos settings are available.
+    // Run the Spark job to load data to OpenSearch. Ensure Kerberos settings are available.
     SparkApp sparkReadData = config.createClusterTask('sparkReadData', SparkApp.class) {
         clusterConfiguration = config
         useCluster(testClusters.integTest)

--- a/qa/kerberos/src/itest/java/org/opensearch/hadoop/qa/kerberos/AbstractKerberosClientTest.java
+++ b/qa/kerberos/src/itest/java/org/opensearch/hadoop/qa/kerberos/AbstractKerberosClientTest.java
@@ -406,7 +406,7 @@ public class AbstractKerberosClientTest {
                     testSettings.asProperties().remove(ConfigurationOptions.OPENSEARCH_SECURITY_AUTHENTICATION);
                     testSettings.asProperties().remove(ConfigurationOptions.OPENSEARCH_NET_SPNEGO_AUTH_OPENSEARCH_PRINCIPAL);
 
-                    // Use token to contact ES
+                    // Use token to contact OpenSearch
                     restClient = new RestClient(testSettings);
                     List<NodeInfo> httpDataNodes = restClient.getHttpDataNodes();
                     assertThat(httpDataNodes.size(), is(greaterThan(0)));

--- a/qa/kerberos/src/main/resources/hive/patches/1.2.2/beeline.sh
+++ b/qa/kerberos/src/main/resources/hive/patches/1.2.2/beeline.sh
@@ -26,7 +26,7 @@ beeline () {
   CLASS=org.opensearch.hadoop.qa.kerberos.hive.SecureBeeline;
   BEELINECLASS=org.apache.hive.beeline.BeeLine;
 
-  # add our test jar path for ES-Hadoop
+  # add our test jar path for OpenSearch-Hadoop
   testJarPath=`ls ${TEST_LIB}`
 
   # include only the beeline client jar and its dependencies

--- a/qa/kerberos/src/main/resources/hive/patches/3.1.2/beeline.sh
+++ b/qa/kerberos/src/main/resources/hive/patches/3.1.2/beeline.sh
@@ -27,7 +27,7 @@ beeline () {
   CLASS=org.opensearch.hadoop.qa.kerberos.hive.SecureBeeline;
   BEELINECLASS=org.apache.hive.beeline.BeeLine;
 
-  # add our test jar path for ES-Hadoop
+  # add our test jar path for OpenSearch-Hadoop
   testJarPath=`ls ${TEST_LIB}`
   # ==Change
 

--- a/qa/kerberos/src/main/scala/org/opensearch/hadoop/qa/kerberos/spark/LoadToES.scala
+++ b/qa/kerberos/src/main/scala/org/opensearch/hadoop/qa/kerberos/spark/LoadToES.scala
@@ -53,8 +53,8 @@ class LoadToES(args: Array[String]) {
       .option("sep", "\t")
       .csv(args(0))
 
-    df.rdd.map(row => row.getValuesMap(row.schema.fieldNames)).saveToEs(s"${resource}_rdd")
-    df.saveToEs(s"${resource}_df")
+    df.rdd.map(row => row.getValuesMap(row.schema.fieldNames)).saveToOpenSearch(s"${resource}_rdd")
+    df.saveToOpenSearch(s"${resource}_df")
     df.write.format("opensearch").save(s"${resource}_ds")
   }
 }

--- a/spark/core/src/main/scala/org/opensearch/spark/package.scala
+++ b/spark/core/src/main/scala/org/opensearch/spark/package.scala
@@ -44,12 +44,12 @@ package object spark {
   implicit def sparkContextFunctions(sc: SparkContext)= new SparkContextFunctions(sc)
 
   class SparkContextFunctions(sc: SparkContext) extends Serializable {
-    def esRDD() = OpenSearchSpark.opensearchRDD(sc)
-    def esRDD(resource: String) = OpenSearchSpark.esRDD(sc, resource)
-    def esRDD(resource: String, query: String) = OpenSearchSpark.esRDD(sc, resource, query)
-    def esRDD(cfg: scala.collection.Map[String, String]) = OpenSearchSpark.esRDD(sc, cfg)
-    def esRDD(resource: String, cfg: scala.collection.Map[String, String]) = OpenSearchSpark.esRDD(sc, resource, cfg)
-    def esRDD(resource: String, query: String, cfg: scala.collection.Map[String, String]) = OpenSearchSpark.esRDD(sc, resource, query, cfg)
+    def opensearchRDD() = OpenSearchSpark.opensearchRDD(sc)
+    def opensearchRDD(resource: String) = OpenSearchSpark.opensearchRDD(sc, resource)
+    def opensearchRDD(resource: String, query: String) = OpenSearchSpark.opensearchRDD(sc, resource, query)
+    def opensearchRDD(cfg: scala.collection.Map[String, String]) = OpenSearchSpark.opensearchRDD(sc, cfg)
+    def opensearchRDD(resource: String, cfg: scala.collection.Map[String, String]) = OpenSearchSpark.opensearchRDD(sc, resource, cfg)
+    def opensearchRDD(resource: String, query: String, cfg: scala.collection.Map[String, String]) = OpenSearchSpark.opensearchRDD(sc, resource, query, cfg)
 
     def esJsonRDD() = OpenSearchSpark.esJsonRDD(sc)
     def esJsonRDD(resource: String) = OpenSearchSpark.esJsonRDD(sc, resource)
@@ -62,9 +62,9 @@ package object spark {
   implicit def sparkRDDFunctions[T : ClassTag](rdd: RDD[T]) = new SparkRDDFunctions[T](rdd)
 
   class SparkRDDFunctions[T : ClassTag](rdd: RDD[T]) extends Serializable {
-    def saveToEs(resource: String): Unit = { OpenSearchSpark.saveToEs(rdd, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSpark.saveToEs(rdd, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSpark.saveToEs(rdd, cfg)    }
+    def saveToOpenSearch(resource: String): Unit = { OpenSearchSpark.saveToOpenSearch(rdd, resource) }
+    def saveToOpenSearch(resource: String, cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSpark.saveToOpenSearch(rdd, resource, cfg) }
+    def saveToOpenSearch(cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSpark.saveToOpenSearch(rdd, cfg)    }
   }
 
   implicit def sparkStringJsonRDDFunctions(rdd: RDD[String]) = new SparkJsonRDDFunctions[String](rdd)
@@ -79,8 +79,8 @@ package object spark {
   implicit def sparkPairRDDFunctions[K : ClassTag, V : ClassTag](rdd: RDD[(K,V)]) = new SparkPairRDDFunctions[K,V](rdd)
 
   class SparkPairRDDFunctions[K : ClassTag, V : ClassTag](rdd: RDD[(K,V)]) extends Serializable {
-    def saveToEsWithMeta[K,V](resource: String): Unit = { OpenSearchSpark.saveToEsWithMeta(rdd, resource) }
-    def saveToEsWithMeta[K,V](resource: String, cfg: Map[String, String]): Unit = { OpenSearchSpark.saveToEsWithMeta(rdd, resource, cfg) }
-    def saveToEsWithMeta[K,V](cfg: Map[String, String]): Unit = { OpenSearchSpark.saveToEsWithMeta(rdd, cfg) }
+    def saveToOpenSearchWithMeta[K,V](resource: String): Unit = { OpenSearchSpark.saveToOpenSearchWithMeta(rdd, resource) }
+    def saveToOpenSearchWithMeta[K,V](resource: String, cfg: Map[String, String]): Unit = { OpenSearchSpark.saveToOpenSearchWithMeta(rdd, resource, cfg) }
+    def saveToOpenSearchWithMeta[K,V](cfg: Map[String, String]): Unit = { OpenSearchSpark.saveToOpenSearchWithMeta(rdd, cfg) }
   }
 }

--- a/spark/core/src/main/scala/org/opensearch/spark/rdd/CompatUtils.java
+++ b/spark/core/src/main/scala/org/opensearch/spark/rdd/CompatUtils.java
@@ -140,7 +140,7 @@ abstract class CompatUtils {
     static void warnSchemaRDD(Object rdd, Log log) {
         if (rdd != null && SCHEMA_RDD_LIKE_CLASS != null) {
             if (SCHEMA_RDD_LIKE_CLASS.isAssignableFrom(rdd.getClass())) {
-                log.warn("basic RDD saveToEs() called on a Spark SQL SchemaRDD; typically this is a mistake(as the SQL schema will be ignored). Use 'org.opensearch.spark.sql' package instead");
+                log.warn("basic RDD saveToOpenSearch() called on a Spark SQL SchemaRDD; typically this is a mistake(as the SQL schema will be ignored). Use 'org.opensearch.spark.sql' package instead");
             }
         }
     }

--- a/spark/core/src/main/scala/org/opensearch/spark/rdd/OpenSearchSpark.scala
+++ b/spark/core/src/main/scala/org/opensearch/spark/rdd/OpenSearchSpark.scala
@@ -52,15 +52,15 @@ object OpenSearchSpark {
   //
 
   def opensearchRDD(sc: SparkContext): RDD[(String, Map[String, AnyRef])] = new ScalaOpenSearchRDD[Map[String, AnyRef]](sc)
-  def esRDD(sc: SparkContext, cfg: Map[String, String]): RDD[(String, Map[String, AnyRef])] =
+  def opensearchRDD(sc: SparkContext, cfg: Map[String, String]): RDD[(String, Map[String, AnyRef])] =
     new ScalaOpenSearchRDD[Map[String, AnyRef]](sc, cfg)
-  def esRDD(sc: SparkContext, resource: String): RDD[(String, Map[String, AnyRef])] =
+  def opensearchRDD(sc: SparkContext, resource: String): RDD[(String, Map[String, AnyRef])] =
     new ScalaOpenSearchRDD[Map[String, AnyRef]](sc, Map(OPENSEARCH_RESOURCE_READ -> resource))
-  def esRDD(sc: SparkContext, resource: String, query: String): RDD[(String, Map[String, AnyRef])] =
+  def opensearchRDD(sc: SparkContext, resource: String, query: String): RDD[(String, Map[String, AnyRef])] =
     new ScalaOpenSearchRDD[Map[String, AnyRef]](sc, Map(OPENSEARCH_RESOURCE_READ -> resource, OPENSEARCH_QUERY -> query))
-  def esRDD(sc: SparkContext, resource: String, cfg: Map[String, String]): RDD[(String, Map[String, AnyRef])] =
+  def opensearchRDD(sc: SparkContext, resource: String, cfg: Map[String, String]): RDD[(String, Map[String, AnyRef])] =
     new ScalaOpenSearchRDD[Map[String, AnyRef]](sc, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_READ -> resource))
-  def esRDD(sc: SparkContext, resource: String, query: String, cfg: Map[String, String]): RDD[(String, Map[String, AnyRef])] =
+  def opensearchRDD(sc: SparkContext, resource: String, query: String, cfg: Map[String, String]): RDD[(String, Map[String, AnyRef])] =
     new ScalaOpenSearchRDD[Map[String, AnyRef]](sc, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_READ -> resource, OPENSEARCH_QUERY -> query))
 
 
@@ -81,20 +81,20 @@ object OpenSearchSpark {
   //
   // Save methods
   //
-  def saveToEs(rdd: RDD[_], resource: String): Unit = { saveToEs(rdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource)) }
-  def saveToEs(rdd: RDD[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(rdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(rdd: RDD[_], resource: String): Unit = { saveToOpenSearch(rdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource)) }
+  def saveToOpenSearch(rdd: RDD[_], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearch(rdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(rdd: RDD[_], cfg: Map[String, String]): Unit =  {
+  def saveToOpenSearch(rdd: RDD[_], cfg: Map[String, String]): Unit =  {
     doSaveToEs(rdd, cfg, false)
   }
 
   // Save with metadata
-  def saveToEsWithMeta[K,V](rdd: RDD[(K,V)], resource: String): Unit = { saveToEsWithMeta(rdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource)) }
-  def saveToEsWithMeta[K,V](rdd: RDD[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEsWithMeta(rdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearchWithMeta[K,V](rdd: RDD[(K,V)], resource: String): Unit = { saveToOpenSearchWithMeta(rdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource)) }
+  def saveToOpenSearchWithMeta[K,V](rdd: RDD[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearchWithMeta(rdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](rdd: RDD[(K,V)], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearchWithMeta[K,V](rdd: RDD[(K,V)], cfg: Map[String, String]): Unit = {
     doSaveToEs(rdd, cfg, true)
   }
 
@@ -119,11 +119,11 @@ object OpenSearchSpark {
   }
 
   // JSON variant
-  def saveJsonToEs(rdd: RDD[_], resource: String): Unit = { saveToEs(rdd, resource, Map(OPENSEARCH_INPUT_JSON -> true.toString)) }
+  def saveJsonToEs(rdd: RDD[_], resource: String): Unit = { saveToOpenSearch(rdd, resource, Map(OPENSEARCH_INPUT_JSON -> true.toString)) }
   def saveJsonToEs(rdd: RDD[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(rdd, resource, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(rdd, resource, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
   }
   def saveJsonToEs(rdd: RDD[_], cfg: Map[String, String]): Unit = {
-    saveToEs(rdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(rdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
   }
 }

--- a/spark/core/src/main/scala/org/opensearch/spark/rdd/api/java/JavaOpenSearchSpark.scala
+++ b/spark/core/src/main/scala/org/opensearch/spark/rdd/api/java/JavaOpenSearchSpark.scala
@@ -45,12 +45,12 @@ import org.opensearch.spark.rdd.JavaOpenSearchRDD
 object JavaOpenSearchSpark {
 
   // specify the return types to make sure the bytecode is generated properly (w/o any scala.collections in it)
-  def esRDD(jsc: JavaSparkContext): JavaPairRDD[String, JMap[String, Object]] = fromRDD(new JavaOpenSearchRDD[JMap[String, Object]](jsc.sc))
-  def esRDD(jsc: JavaSparkContext, resource: String): JavaPairRDD[String, JMap[String, Object]] =
+  def opensearchRDD(jsc: JavaSparkContext): JavaPairRDD[String, JMap[String, Object]] = fromRDD(new JavaOpenSearchRDD[JMap[String, Object]](jsc.sc))
+  def opensearchRDD(jsc: JavaSparkContext, resource: String): JavaPairRDD[String, JMap[String, Object]] =
     fromRDD(new JavaOpenSearchRDD[JMap[String, Object]](jsc.sc, Map(OPENSEARCH_RESOURCE_READ -> resource)))
-  def esRDD(jsc: JavaSparkContext, resource: String, query: String): JavaPairRDD[String, JMap[String, Object]] =
+  def opensearchRDD(jsc: JavaSparkContext, resource: String, query: String): JavaPairRDD[String, JMap[String, Object]] =
     fromRDD(new JavaOpenSearchRDD[JMap[String, Object]](jsc.sc, Map(OPENSEARCH_RESOURCE_READ -> resource, OPENSEARCH_QUERY -> query)))
-  def esRDD(jsc: JavaSparkContext, cfg: JMap[String, String]): JavaPairRDD[String, JMap[String, Object]] =
+  def opensearchRDD(jsc: JavaSparkContext, cfg: JMap[String, String]): JavaPairRDD[String, JMap[String, Object]] =
     fromRDD(new JavaOpenSearchRDD[JMap[String, Object]](jsc.sc, cfg.asScala))
 
   def esJsonRDD(jsc: JavaSparkContext): JavaPairRDD[String, String] = fromRDD(new JavaOpenSearchRDD[String](jsc.sc, Map(OPENSEARCH_OUTPUT_JSON -> true.toString)))
@@ -61,13 +61,13 @@ object JavaOpenSearchSpark {
   def esJsonRDD(jsc: JavaSparkContext, cfg: JMap[String, String]): JavaPairRDD[String, String] =
     fromRDD(new JavaOpenSearchRDD[String](jsc.sc, cfg.asScala += (OPENSEARCH_OUTPUT_JSON -> true.toString)))
 
-  def saveToEs(jrdd: JavaRDD[_], resource: String) = OpenSearchSpark.saveToEs(jrdd.rdd, resource)
-  def saveToEs(jrdd: JavaRDD[_], resource: String, cfg: JMap[String, String]) = OpenSearchSpark.saveToEs(jrdd.rdd, resource, cfg.asScala)
-  def saveToEs(jrdd: JavaRDD[_], cfg: JMap[String, String]) = OpenSearchSpark.saveToEs(jrdd.rdd, cfg.asScala)
+  def saveToOpenSearch(jrdd: JavaRDD[_], resource: String) = OpenSearchSpark.saveToOpenSearch(jrdd.rdd, resource)
+  def saveToOpenSearch(jrdd: JavaRDD[_], resource: String, cfg: JMap[String, String]) = OpenSearchSpark.saveToOpenSearch(jrdd.rdd, resource, cfg.asScala)
+  def saveToOpenSearch(jrdd: JavaRDD[_], cfg: JMap[String, String]) = OpenSearchSpark.saveToOpenSearch(jrdd.rdd, cfg.asScala)
 
-  def saveToEsWithMeta[K, V](jrdd: JavaPairRDD[K, V], resource: String) = OpenSearchSpark.saveToEsWithMeta(jrdd.rdd, resource)
-  def saveToEsWithMeta[K, V](jrdd: JavaPairRDD[K, V], resource: String, cfg: JMap[String, String]) = OpenSearchSpark.saveToEsWithMeta(jrdd.rdd, resource, cfg.asScala)
-  def saveToEsWithMeta[K, V](jrdd: JavaPairRDD[K, V], cfg: JMap[String, String]) = OpenSearchSpark.saveToEsWithMeta(jrdd.rdd, cfg.asScala)
+  def saveToOpenSearchWithMeta[K, V](jrdd: JavaPairRDD[K, V], resource: String) = OpenSearchSpark.saveToOpenSearchWithMeta(jrdd.rdd, resource)
+  def saveToOpenSearchWithMeta[K, V](jrdd: JavaPairRDD[K, V], resource: String, cfg: JMap[String, String]) = OpenSearchSpark.saveToOpenSearchWithMeta(jrdd.rdd, resource, cfg.asScala)
+  def saveToOpenSearchWithMeta[K, V](jrdd: JavaPairRDD[K, V], cfg: JMap[String, String]) = OpenSearchSpark.saveToOpenSearchWithMeta(jrdd.rdd, cfg.asScala)
 
   def saveJsonToEs(jrdd: JavaRDD[String], resource: String) = OpenSearchSpark.saveJsonToEs(jrdd.rdd, resource)
   def saveJsonToEs(jrdd: JavaRDD[String], resource: String, cfg: JMap[String, String]) = OpenSearchSpark.saveJsonToEs(jrdd.rdd, resource, cfg.asScala)

--- a/spark/core/src/main/scala/org/opensearch/spark/serialization/ScalaValueWriter.scala
+++ b/spark/core/src/main/scala/org/opensearch/spark/serialization/ScalaValueWriter.scala
@@ -138,7 +138,7 @@ class ScalaValueWriter(writeUnknownTypes: Boolean = false) extends JdkValueWrite
       case _ => {
         // check if it's called by accident on a DataFrame/SchemaRDD (happens)
         if (value.getClass().getName().startsWith("org.apache.spark.sql.")) {
-          throw new OpenSearchHadoopIllegalArgumentException("Spark SQL types are not handled through basic RDD saveToEs() calls; typically this is a mistake(as the SQL schema will be ignored). Use 'org.opensearch.spark.sql' package instead")
+          throw new OpenSearchHadoopIllegalArgumentException("Spark SQL types are not handled through basic RDD saveToOpenSearch() calls; typically this is a mistake(as the SQL schema will be ignored). Use 'org.opensearch.spark.sql' package instead")
         }
 
         val result = super.doWrite(value, generator, parentField)

--- a/spark/sql-13/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkSQLTest.java
+++ b/spark/sql-13/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkSQLTest.java
@@ -120,7 +120,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
 		DataFrame dataFrame = artistsAsDataFrame();
 
 		String target = resource("sparksql-test-scala-basic-write", "data", version);
-		JavaOpenSearchSparkSQL.saveToEs(dataFrame, target);
+		JavaOpenSearchSparkSQL.saveToOpenSearch(dataFrame, target);
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
 	}
@@ -132,7 +132,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
 		String target = resource("sparksql-test-scala-basic-write-id-mapping", "data", version);
 		String docEndpoint = docEndpoint("sparksql-test-scala-basic-write-id-mapping", "data", version);
 
-		JavaOpenSearchSparkSQL.saveToEs(dataFrame, target,
+		JavaOpenSearchSparkSQL.saveToOpenSearch(dataFrame, target,
 				ImmutableMap.of(OPENSEARCH_MAPPING_ID, "id"));
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
@@ -144,7 +144,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
     	DataFrame dataFrame = artistsAsDataFrame();
 
         String target = resource("sparksql-test-scala-basic-write-exclude-mapping", "data", version);
-        JavaOpenSearchSparkSQL.saveToEs(dataFrame, target,ImmutableMap.of(OPENSEARCH_MAPPING_EXCLUDE, "url"));
+        JavaOpenSearchSparkSQL.saveToOpenSearch(dataFrame, target,ImmutableMap.of(OPENSEARCH_MAPPING_EXCLUDE, "url"));
         assertTrue(RestUtils.exists(target));
         assertThat(RestUtils.get(target + "/_search?"), not(containsString("url")));
     }
@@ -176,7 +176,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
 	public void testOpenSearchDataFrameReadMetadata() throws Exception {
 		DataFrame artists = artistsAsDataFrame();
 		String target = resource("sparksql-test-scala-dataframe-read-metadata", "data", version);
-		JavaOpenSearchSparkSQL.saveToEs(artists, target);
+		JavaOpenSearchSparkSQL.saveToOpenSearch(artists, target);
 
 		DataFrame dataframe = sqc.read().format("opensearch").option("opensearch.read.metadata", "true").load(target).where("id = 1");
 

--- a/spark/sql-13/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStreamingTest.java
+++ b/spark/sql-13/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStreamingTest.java
@@ -173,7 +173,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         rddQueue.add(batch);
         JavaInputDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue, true);
         // apply closure
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2); // Let the processing happen
         ssc.stop(false, true);
@@ -205,7 +205,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue, true);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2); // Let the processing happen
         ssc.stop(false, true);
@@ -244,12 +244,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/1"));
         assertTrue(RestUtils.exists(docEndpoint + "/2"));
 
@@ -285,12 +285,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
 
         JavaPairDStream<Integer, Map<String, Object>> metaDstream = dstream.mapToPair(new ExtractIDFunction());
 
-        JavaOpenSearchSparkStreaming.saveToEsWithMeta(metaDstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearchWithMeta(metaDstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/3"));
         assertTrue(RestUtils.exists(docEndpoint + "/4"));
 
@@ -336,12 +336,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
 
         JavaPairDStream<Map<Metadata, Object>, Map<String, Object>> metaDstream = dstream.mapToPair(new ExtractMetaMap());
 
-        JavaOpenSearchSparkStreaming.saveToEsWithMeta(metaDstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearchWithMeta(metaDstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/5"));
         assertTrue(RestUtils.exists(docEndpoint + "/6"));
 
@@ -383,7 +383,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
@@ -428,7 +428,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
@@ -457,7 +457,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);

--- a/spark/sql-13/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchScalaSparkStreaming.scala
+++ b/spark/sql-13/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchScalaSparkStreaming.scala
@@ -127,7 +127,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val target = wrapIndex(resource("spark-test-nonexisting", "scala-basic-write", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
-    runStream(batch)(_.saveToEs(target, cfg + (OPENSEARCH_INDEX_AUTO_CREATE -> "no")))
+    runStream(batch)(_.saveToOpenSearch(target, cfg + (OPENSEARCH_INDEX_AUTO_CREATE -> "no")))
 
     assertTrue(!RestUtils.exists(target))
     expecting.assertExceptionFound()
@@ -142,7 +142,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
-    runStream(batch)(_.saveToEs(target, cfg))
+    runStream(batch)(_.saveToOpenSearch(target, cfg))
 
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("OTP"))
@@ -158,7 +158,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
-    runStream(batch)(_.saveToEs(target, cfg))
+    runStream(batch)(_.saveToOpenSearch(target, cfg))
 
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("OTP"))
@@ -170,7 +170,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
   //   val expected = ExpectingToThrow(classOf[SparkException]).from(ssc)
   //   val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Garbage(5))
   //   val batch = sc.makeRDD(Seq(doc))
-  //   runStream(batch)(_.saveToEs(wrapIndex(resource("spark-streaming-test-nested-map", "data", version)), cfg))
+  //   runStream(batch)(_.saveToOpenSearch(wrapIndex(resource("spark-streaming-test-nested-map", "data", version)), cfg))
   //   expected.assertExceptionFound()
   // }
 
@@ -185,13 +185,13 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val target = wrapIndex(resource("spark-streaming-test-scala-basic-write-objects", "data", version))
 
     val batch = sc.makeRDD(Seq(javaBean, caseClass1))
-    runStreamRecoverably(batch)(_.saveToEs(target, cfg))
+    runStreamRecoverably(batch)(_.saveToOpenSearch(target, cfg))
 
     val batch2 = sc.makeRDD(Seq(javaBean, caseClass2))
-    runStream(batch2)(_.saveToEs(target, Map("opensearch.mapping.id"->"id")))
+    runStream(batch2)(_.saveToOpenSearch(target, Map("opensearch.mapping.id"->"id")))
 
     assertTrue(RestUtils.exists(target))
-    assertEquals(3, OpenSearchSpark.esRDD(sc, target).count())
+    assertEquals(3, OpenSearchSpark.opensearchRDD(sc, target).count())
     assertThat(RestUtils.get(target + "/_search?"), containsString(""))
   }
 
@@ -204,9 +204,9 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-id-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
-    runStream(batch)(_.saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "number")))
+    runStream(batch)(_.saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "number")))
 
-    assertEquals(2, OpenSearchSpark.esRDD(sc, target).count())
+    assertEquals(2, OpenSearchSpark.opensearchRDD(sc, target).count())
     assertTrue(RestUtils.exists(docPath + "/1"))
     assertTrue(RestUtils.exists(docPath + "/2"))
 
@@ -222,11 +222,11 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-dyn-id-write", "data", version))
 
     val pairRDD = sc.makeRDD(Seq((3, doc1), (4, doc2)))
-    runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
+    runStream(pairRDD)(_.saveToOpenSearchWithMeta(target, cfg))
 
     println(RestUtils.get(target + "/_search?"))
 
-    assertEquals(2, OpenSearchSpark.esRDD(sc, target).count())
+    assertEquals(2, OpenSearchSpark.opensearchRDD(sc, target).count())
     assertTrue(RestUtils.exists(docPath + "/3"))
     assertTrue(RestUtils.exists(docPath + "/4"))
 
@@ -249,7 +249,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
 
     val pairRDD = sc.makeRDD(Seq((metadata1, doc1), (metadata2, doc2)))
 
-    runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
+    runStream(pairRDD)(_.saveToOpenSearchWithMeta(target, cfg))
 
     assertTrue(RestUtils.exists(docPath + "/5"))
     assertTrue(RestUtils.exists(docPath + "/6"))
@@ -265,7 +265,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data", version))
 
     val batch = sc.makeRDD(Seq(trip1, trip2))
-    runStream(batch)(_.saveToEs(target, Map(OPENSEARCH_MAPPING_EXCLUDE -> "airport")))
+    runStream(batch)(_.saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_EXCLUDE -> "airport")))
 
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("business"))
@@ -289,7 +289,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val ingestCfg = cfg + (ConfigurationOptions.OPENSEARCH_INGEST_PIPELINE -> pipelineName) + (ConfigurationOptions.OPENSEARCH_NODES_INGEST_ONLY -> "true")
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
-    runStream(batch)(_.saveToEs(target, ingestCfg))
+    runStream(batch)(_.saveToOpenSearch(target, ingestCfg))
 
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("\"pipeTEST\":true"))
@@ -304,7 +304,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
 
     val target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data", version))
     val batch = sc.makeRDD(Seq(trip1, trip2))
-    runStream(batch)(_.saveToEs(target, cfg))
+    runStream(batch)(_.saveToOpenSearch(target, cfg))
 
     assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data", version))))
     assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data", version))))
@@ -379,14 +379,14 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val up_script = {
       "ctx._source.address.add(params.new_address)"
     }
-    runStreamRecoverably(lines)(_.saveToEs(target, props + ("opensearch.update.script.params" -> up_params) + ("opensearch.update.script" -> up_script)))
+    runStreamRecoverably(lines)(_.saveToOpenSearch(target, props + ("opensearch.update.script.params" -> up_params) + ("opensearch.update.script" -> up_script)))
 
     // Upsert a value that should only modify the second document. Modification will update the "note" field.
     val notes = sc.makeRDD(List("""{"id":"2","note":"Second"}"""))
     val note_up_params = "new_note:note"
     val note_up_script = "ctx._source.note = params.new_note"
 
-    runStream(notes)(_.saveToEs(target, props + ("opensearch.update.script.params" -> note_up_params) + ("opensearch.update.script" -> note_up_script)))
+    runStream(notes)(_.saveToOpenSearch(target, props + ("opensearch.update.script.params" -> note_up_params) + ("opensearch.update.script" -> note_up_script)))
 
     assertTrue(RestUtils.exists(s"$docPath/1"))
     assertThat(RestUtils.get(s"$docPath/1"), both(containsString(""""zipcode":"12345"""")).and(containsString(""""note":"First"""")))
@@ -405,9 +405,9 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val target = wrapIndex(resource("spark-streaming-test-nullasempty", "data", version))
     val batch = sc.makeRDD(data)
 
-    runStream(batch)(_.saveToEs(target))
+    runStream(batch)(_.saveToOpenSearch(target))
 
-    assertEquals(3, OpenSearchSpark.esRDD(sc, target, cfg).count())
+    assertEquals(3, OpenSearchSpark.opensearchRDD(sc, target, cfg).count())
   }
 
   def wrapMapping(typeName: String, typelessMapping: String): String = {

--- a/spark/sql-13/src/main/scala/org/opensearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-13/src/main/scala/org/opensearch/spark/sql/DefaultSource.scala
@@ -549,7 +549,7 @@ private[sql] case class OpenSearchRelation(parameters: Map[String, String], @tra
       }
       rr.close()
     }
-    OpenSearchSparkSQL.saveToEs(data, parameters)
+    OpenSearchSparkSQL.saveToOpenSearch(data, parameters)
   }
 
   def isEmpty(): Boolean = {

--- a/spark/sql-13/src/main/scala/org/opensearch/spark/sql/OpenSearchSparkSQL.scala
+++ b/spark/sql-13/src/main/scala/org/opensearch/spark/sql/OpenSearchSparkSQL.scala
@@ -71,13 +71,13 @@ object OpenSearchSparkSQL {
   }
 
 
-  def saveToEs(srdd: DataFrame, resource: String): Unit = {
-    saveToEs(srdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(srdd: DataFrame, resource: String): Unit = {
+    saveToOpenSearch(srdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(srdd: DataFrame, resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(srdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(srdd: DataFrame, resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearch(srdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(srdd: DataFrame, cfg: Map[String, String]): Unit = {
+  def saveToOpenSearch(srdd: DataFrame, cfg: Map[String, String]): Unit = {
     if (srdd != null) {
       val sparkCtx = srdd.sqlContext.sparkContext
       val sparkCfg = new SparkSettingsManager().load(sparkCtx.getConf)

--- a/spark/sql-13/src/main/scala/org/opensearch/spark/sql/api/java/JavaOpenSearchSparkSQL.scala
+++ b/spark/sql-13/src/main/scala/org/opensearch/spark/sql/api/java/JavaOpenSearchSparkSQL.scala
@@ -51,7 +51,7 @@ object JavaOpenSearchSparkSQL {
   def esDF(sc: SQLContext, resource: String, query: String, cfg: JMap[String, String]): DataFrame = OpenSearchSparkSQL.esDF(sc, resource, query, cfg.asScala)
 
   
-  def saveToEs(df: DataFrame, resource: String) = OpenSearchSparkSQL.saveToEs(df , resource)
-  def saveToEs(df: DataFrame, resource: String, cfg: JMap[String, String]) = OpenSearchSparkSQL.saveToEs(df, resource, cfg.asScala)
-  def saveToEs(df: DataFrame, cfg: JMap[String, String]) = OpenSearchSparkSQL.saveToEs(df, cfg.asScala)
+  def saveToOpenSearch(df: DataFrame, resource: String) = OpenSearchSparkSQL.saveToOpenSearch(df , resource)
+  def saveToOpenSearch(df: DataFrame, resource: String, cfg: JMap[String, String]) = OpenSearchSparkSQL.saveToOpenSearch(df, resource, cfg.asScala)
+  def saveToOpenSearch(df: DataFrame, cfg: JMap[String, String]) = OpenSearchSparkSQL.saveToOpenSearch(df, cfg.asScala)
 }

--- a/spark/sql-13/src/main/scala/org/opensearch/spark/sql/package.scala
+++ b/spark/sql-13/src/main/scala/org/opensearch/spark/sql/package.scala
@@ -54,8 +54,8 @@ package object sql {
 
   @deprecated(message="Support for Apache Spark 1 is deprecated. Use Spark 2 or 3.")
   class SparkDataFrameFunctions(df: DataFrame) extends Serializable {
-    def saveToEs(resource: String): Unit = { OpenSearchSparkSQL.saveToEs(df, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToEs(df, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToEs(df, cfg)    }
+    def saveToOpenSearch(resource: String): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, resource) }
+    def saveToOpenSearch(resource: String, cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, resource, cfg) }
+    def saveToOpenSearch(cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, cfg)    }
   }
 }

--- a/spark/sql-13/src/main/scala/org/opensearch/spark/streaming/OpenSearchSparkStreaming.scala
+++ b/spark/sql-13/src/main/scala/org/opensearch/spark/streaming/OpenSearchSparkStreaming.scala
@@ -41,36 +41,36 @@ import scala.collection.Map
 object OpenSearchSparkStreaming {
 
   // Save methods
-  def saveToEs(ds: DStream[_], resource: String): Unit = {
-    saveToEs(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(ds: DStream[_], resource: String): Unit = {
+    saveToOpenSearch(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearch(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearch(ds: DStream[_], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = false)
   }
 
   // Save with metadata
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String): Unit = {
-    saveToEsWithMeta(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], resource: String): Unit = {
+    saveToOpenSearchWithMeta(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEsWithMeta(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearchWithMeta(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = true)
   }
 
   // Save as JSON
   def saveJsonToEs(ds: DStream[_], resource: String): Unit = {
-    saveToEs(ds, resource, Map(OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, resource, Map(OPENSEARCH_INPUT_JSON -> true.toString))
   }
   def saveJsonToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(ds, resource, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, resource, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
   }
   def saveJsonToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
-    saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
   }
 
   // Implementation

--- a/spark/sql-13/src/main/scala/org/opensearch/spark/streaming/api/java/JavaOpenSearchSparkStreaming.scala
+++ b/spark/sql-13/src/main/scala/org/opensearch/spark/streaming/api/java/JavaOpenSearchSparkStreaming.scala
@@ -39,13 +39,13 @@ import org.opensearch.spark.streaming.OpenSearchSparkStreaming
 object JavaOpenSearchSparkStreaming {
 
   // specify the return types to make sure the bytecode is generated properly (w/o any scala.collections in it)
-  def saveToEs(ds: JavaDStream[_], resource: String): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, resource)
-  def saveToEs(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, resource, cfg.asScala)
-  def saveToEs(ds: JavaDStream[_], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, cfg.asScala)
+  def saveToOpenSearch(ds: JavaDStream[_], resource: String): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, resource)
+  def saveToOpenSearch(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, resource, cfg.asScala)
+  def saveToOpenSearch(ds: JavaDStream[_], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, cfg.asScala)
 
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, resource)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, resource, cfg.asScala)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, cfg.asScala)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, resource)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, resource, cfg.asScala)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, cfg.asScala)
 
   def saveJsonToEs(ds: JavaDStream[String], resource: String): Unit = OpenSearchSparkStreaming.saveJsonToEs(ds.dstream, resource)
   def saveJsonToEs(ds: JavaDStream[String], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)

--- a/spark/sql-13/src/main/scala/org/opensearch/spark/streaming/package.scala
+++ b/spark/sql-13/src/main/scala/org/opensearch/spark/streaming/package.scala
@@ -41,9 +41,9 @@ package object streaming {
   implicit def sparkDStreamFunctions(ds: DStream[_]): SparkDStreamFunctions = new SparkDStreamFunctions(ds)
 
   class SparkDStreamFunctions(ds: DStream[_]) extends Serializable {
-    def saveToEs(resource: String): Unit = { OpenSearchSparkStreaming.saveToEs(ds, resource) }
-    def saveToEs(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEs(ds, resource, cfg) }
-    def saveToEs(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEs(ds, cfg) }
+    def saveToOpenSearch(resource: String): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, resource) }
+    def saveToOpenSearch(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, resource, cfg) }
+    def saveToOpenSearch(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, cfg) }
   }
 
   implicit def sparkStringJsonDStreamFunctions(ds: DStream[String]): SparkJsonDStreamFunctions[String] = new SparkJsonDStreamFunctions[String](ds)
@@ -58,9 +58,9 @@ package object streaming {
   implicit def sparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K,V)]): SparkPairDStreamFunctions[K,V] = new SparkPairDStreamFunctions[K,V](ds)
 
   class SparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K, V)]) extends Serializable {
-    def saveToEsWithMeta(resource: String): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, resource) }
-    def saveToEsWithMeta(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, resource, cfg) }
-    def saveToEsWithMeta(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, cfg) }
+    def saveToOpenSearchWithMeta(resource: String): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, resource) }
+    def saveToOpenSearchWithMeta(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, resource, cfg) }
+    def saveToOpenSearchWithMeta(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, cfg) }
   }
 
 }

--- a/spark/sql-20/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkSQLTest.java
+++ b/spark/sql-20/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkSQLTest.java
@@ -120,7 +120,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
         Dataset<Row> dataset = artistsAsDataset();
 
 		String target = resource("sparksql-test-scala-basic-write", "data", version);
-        JavaOpenSearchSparkSQL.saveToEs(dataset, target);
+        JavaOpenSearchSparkSQL.saveToOpenSearch(dataset, target);
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
 	}
@@ -132,7 +132,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
 		String target = resource("sparksql-test-scala-basic-write-id-mapping", "data", version);
 		String docEndpoint = docEndpoint("sparksql-test-scala-basic-write-id-mapping", "data", version);
 
-        JavaOpenSearchSparkSQL.saveToEs(dataset, target,
+        JavaOpenSearchSparkSQL.saveToOpenSearch(dataset, target,
 				ImmutableMap.of(OPENSEARCH_MAPPING_ID, "id"));
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
@@ -144,7 +144,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
         Dataset<Row> dataset = artistsAsDataset();
 
         String target = resource("sparksql-test-scala-basic-write-exclude-mapping", "data", version);
-        JavaOpenSearchSparkSQL.saveToEs(dataset, target,
+        JavaOpenSearchSparkSQL.saveToOpenSearch(dataset, target,
                 ImmutableMap.of(OPENSEARCH_MAPPING_EXCLUDE, "url"));
         assertTrue(RestUtils.exists(target));
         assertThat(RestUtils.get(target + "/_search?"), not(containsString("url")));

--- a/spark/sql-20/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStreamingTest.java
+++ b/spark/sql-20/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStreamingTest.java
@@ -173,7 +173,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         rddQueue.add(batch);
         JavaInputDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue, true);
         // apply closure
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2); // Let the processing happen
         ssc.stop(false, true);
@@ -205,7 +205,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue, true);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2); // Let the processing happen
         ssc.stop(false, true);
@@ -244,12 +244,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/1"));
         assertTrue(RestUtils.exists(docEndpoint + "/2"));
 
@@ -285,12 +285,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
 
         JavaPairDStream<Integer, Map<String, Object>> metaDstream = dstream.mapToPair(new ExtractIDFunction());
 
-        JavaOpenSearchSparkStreaming.saveToEsWithMeta(metaDstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearchWithMeta(metaDstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/3"));
         assertTrue(RestUtils.exists(docEndpoint + "/4"));
 
@@ -336,12 +336,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
 
         JavaPairDStream<Map<Metadata, Object>, Map<String, Object>> metaDstream = dstream.mapToPair(new ExtractMetaMap());
 
-        JavaOpenSearchSparkStreaming.saveToEsWithMeta(metaDstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearchWithMeta(metaDstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/5"));
         assertTrue(RestUtils.exists(docEndpoint + "/6"));
 
@@ -383,7 +383,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
@@ -428,7 +428,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
@@ -457,7 +457,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);

--- a/spark/sql-20/src/itest/scala/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStructuredStreamingTest.java
+++ b/spark/sql-20/src/itest/scala/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStructuredStreamingTest.java
@@ -271,7 +271,7 @@ public class AbstractJavaOpenSearchSparkStructuredStreamingTest {
                 target
         );
 
-        assertEquals(3, JavaOpenSearchSpark.esRDD(new JavaSparkContext(spark.sparkContext()), target).count());
+        assertEquals(3, JavaOpenSearchSpark.opensearchRDD(new JavaSparkContext(spark.sparkContext()), target).count());
         assertTrue(RestUtils.exists(docPath + "/1"));
         assertTrue(RestUtils.exists(docPath + "/2"));
         assertTrue(RestUtils.exists(docPath + "/3"));

--- a/spark/sql-20/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchScalaSparkStreaming.scala
+++ b/spark/sql-20/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchScalaSparkStreaming.scala
@@ -124,7 +124,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val target = wrapIndex(resource("spark-test-nonexisting-scala-basic-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
-    runStream(batch)(_.saveToEs(target, cfg + (OPENSEARCH_INDEX_AUTO_CREATE -> "no")))
+    runStream(batch)(_.saveToOpenSearch(target, cfg + (OPENSEARCH_INDEX_AUTO_CREATE -> "no")))
 
     assertTrue(!RestUtils.exists(target))
     expecting.assertExceptionFound()
@@ -139,7 +139,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
 
-    runStream(batch)(_.saveToEs(target, cfg))
+    runStream(batch)(_.saveToOpenSearch(target, cfg))
 
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("OTP"))
@@ -151,7 +151,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
   //   val expected = ExpectingToThrow(classOf[SparkException]).from(ssc)
   //   val doc = Map("itemId" -> "1", "map" -> Map("lat" -> 1.23, "lon" -> -70.12), "list" -> ("A", "B", "C"), "unknown" -> new Garbage(0))
   //   val batch = sc.makeRDD(Seq(doc))
-  //   runStream(batch)(_.saveToEs(wrapIndex(resource("spark-streaming-test-nested-map", "data", version)), cfg))
+  //   runStream(batch)(_.saveToOpenSearch(wrapIndex(resource("spark-streaming-test-nested-map", "data", version)), cfg))
   //   expected.assertExceptionFound()
   // }
 
@@ -166,13 +166,13 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val target = wrapIndex(resource("spark-streaming-test-scala-basic-write-objects", "data", version))
 
     val batch = sc.makeRDD(Seq(javaBean, caseClass1))
-    runStreamRecoverably(batch)(_.saveToEs(target, cfg))
+    runStreamRecoverably(batch)(_.saveToOpenSearch(target, cfg))
 
     val batch2 = sc.makeRDD(Seq(javaBean, caseClass2))
-    runStream(batch2)(_.saveToEs(target, Map("opensearch.mapping.id"->"id")))
+    runStream(batch2)(_.saveToOpenSearch(target, Map("opensearch.mapping.id"->"id")))
 
     assertTrue(RestUtils.exists(target))
-    assertEquals(3, OpenSearchSpark.esRDD(sc, target).count())
+    assertEquals(3, OpenSearchSpark.opensearchRDD(sc, target).count())
     assertThat(RestUtils.get(target + "/_search?"), containsString(""))
   }
 
@@ -185,9 +185,9 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-id-write", "data", version))
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
-    runStream(batch)(_.saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "number")))
+    runStream(batch)(_.saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "number")))
 
-    assertEquals(2, OpenSearchSpark.esRDD(sc, target).count())
+    assertEquals(2, OpenSearchSpark.opensearchRDD(sc, target).count())
     assertTrue(RestUtils.exists(docPath + "/1"))
     assertTrue(RestUtils.exists(docPath + "/2"))
 
@@ -203,11 +203,11 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val docPath = wrapIndex(docEndpoint("spark-streaming-test-scala-dyn-id-write", "data", version))
 
     val pairRDD = sc.makeRDD(Seq((3, doc1), (4, doc2)))
-    runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
+    runStream(pairRDD)(_.saveToOpenSearchWithMeta(target, cfg))
 
     println(RestUtils.get(target + "/_search?"))
 
-    assertEquals(2, OpenSearchSpark.esRDD(sc, target).count())
+    assertEquals(2, OpenSearchSpark.opensearchRDD(sc, target).count())
     assertTrue(RestUtils.exists(docPath + "/3"))
     assertTrue(RestUtils.exists(docPath + "/4"))
 
@@ -230,7 +230,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
 
     val pairRDD = sc.makeRDD(Seq((metadata1, doc1), (metadata2, doc2)))
 
-    runStream(pairRDD)(_.saveToEsWithMeta(target, cfg))
+    runStream(pairRDD)(_.saveToOpenSearchWithMeta(target, cfg))
 
     assertTrue(RestUtils.exists(docPath + "/5"))
     assertTrue(RestUtils.exists(docPath + "/6"))
@@ -246,7 +246,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val target = wrapIndex(resource("spark-streaming-test-scala-write-exclude", "data", version))
 
     val batch = sc.makeRDD(Seq(trip1, trip2))
-    runStream(batch)(_.saveToEs(target, Map(OPENSEARCH_MAPPING_EXCLUDE -> "airport")))
+    runStream(batch)(_.saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_EXCLUDE -> "airport")))
 
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("business"))
@@ -270,7 +270,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val ingestCfg = cfg + (ConfigurationOptions.OPENSEARCH_INGEST_PIPELINE -> pipelineName) + (ConfigurationOptions.OPENSEARCH_NODES_INGEST_ONLY -> "true")
 
     val batch = sc.makeRDD(Seq(doc1, doc2))
-    runStream(batch)(_.saveToEs(target, ingestCfg))
+    runStream(batch)(_.saveToOpenSearch(target, ingestCfg))
 
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("\"pipeTEST\":true"))
@@ -284,7 +284,7 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
 
     val target = wrapIndex(resource("spark-streaming-test-trip-{airport}", "data", version))
     val batch = sc.makeRDD(Seq(trip1, trip2))
-    runStream(batch)(_.saveToEs(target, cfg))
+    runStream(batch)(_.saveToOpenSearch(target, cfg))
 
     assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-otp", "data", version))))
     assertTrue(RestUtils.exists(wrapIndex(resource("spark-streaming-test-trip-sfo", "data", version))))
@@ -358,13 +358,13 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val lines = sc.makeRDD(List("""{"id":"1","address":{"zipcode":"12345","id":"1"}}"""))
     val up_params = "new_address:address"
     val up_script = "ctx._source.address.add(params.new_address)"
-    runStreamRecoverably(lines)(_.saveToEs(target, props + ("opensearch.update.script.params" -> up_params) + ("opensearch.update.script" -> up_script)))
+    runStreamRecoverably(lines)(_.saveToOpenSearch(target, props + ("opensearch.update.script.params" -> up_params) + ("opensearch.update.script" -> up_script)))
 
     // Upsert a value that should only modify the second document. Modification will update the "note" field.
     val notes = sc.makeRDD(List("""{"id":"2","note":"Second"}"""))
     val note_up_params = "new_note:note"
     val note_up_script = "ctx._source.note = params.new_note"
-    runStream(notes)(_.saveToEs(target, props + ("opensearch.update.script.params" -> note_up_params) + ("opensearch.update.script" -> note_up_script)))
+    runStream(notes)(_.saveToOpenSearch(target, props + ("opensearch.update.script.params" -> note_up_params) + ("opensearch.update.script" -> note_up_script)))
 
     assertTrue(RestUtils.exists(s"$docPath/1"))
     assertThat(RestUtils.get(s"$docPath/1"), both(containsString(""""zipcode":"12345"""")).and(containsString(""""note":"First"""")))
@@ -383,9 +383,9 @@ class AbstractScalaOpenSearchScalaSparkStreaming(val prefix: String, readMetadat
     val target = wrapIndex(resource("spark-streaming-test-nullasempty", "data", version))
     val batch = sc.makeRDD(data)
 
-    runStream(batch)(_.saveToEs(target))
+    runStream(batch)(_.saveToOpenSearch(target))
 
-    assertEquals(3, OpenSearchSpark.esRDD(sc, target, cfg).count())
+    assertEquals(3, OpenSearchSpark.opensearchRDD(sc, target, cfg).count())
   }
 
   /**

--- a/spark/sql-20/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchSparkSQL.scala
+++ b/spark/sql-20/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchSparkSQL.scala
@@ -285,7 +285,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
   def testEmptyDataFrame() {
     val index = wrapIndex("spark-test-empty-dataframe")
     val (target, _) = makeTargets(index, "data")
-    val idx = sqc.emptyDataFrame.saveToEs(target)
+    val idx = sqc.emptyDataFrame.saveToOpenSearch(target)
   }
 
   @Test(expected = classOf[OpenSearchHadoopIllegalArgumentException])
@@ -293,7 +293,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val newCfg = collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INDEX_AUTO_CREATE -> "no")
     val index = wrapIndex("spark-test-non-existing-empty-dataframe")
     val (target, _) = makeTargets(index, "data")
-    val idx = sqc.emptyDataFrame.saveToEs(target, newCfg)
+    val idx = sqc.emptyDataFrame.saveToOpenSearch(target, newCfg)
   }
 
   @Test
@@ -461,7 +461,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val trip1 = Map("%s" -> "special")
 
-    sc.makeRDD(Seq(trip1)).saveToEs(target)
+    sc.makeRDD(Seq(trip1)).saveToOpenSearch(target)
   }
   
   @Test
@@ -477,7 +477,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("sparksql-test-scala-basic-write")
     val (target, _) = makeTargets(index, "data")
-    dataFrame.saveToEs(target, cfg)
+    dataFrame.saveToOpenSearch(target, cfg)
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
   }
@@ -499,7 +499,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val (target, docPath) = makeTargets(index, "data")
     val newCfg = collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_EXCLUDE -> "url")
 
-    dataFrame.saveToEs(target, newCfg)
+    dataFrame.saveToOpenSearch(target, newCfg)
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
     assertThat(RestUtils.exists(docPath + "/1"), is(true))
@@ -519,7 +519,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val conf = Map(OPENSEARCH_MAPPING_ID -> "id")
     val rdd = sc.makeRDD(docs)
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
-    jsonDF.saveToEs(target, conf)
+    jsonDF.saveToOpenSearch(target, conf)
     RestUtils.refresh(index)
     val hit1 = RestUtils.get(s"$docPath/1")
     val hit2 = RestUtils.get(s"$docPath/2")
@@ -541,7 +541,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val conf = Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_SPARK_DATAFRAME_WRITE_NULL_VALUES -> "true")
     val rdd = sc.makeRDD(docs)
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
-    jsonDF.saveToEs(target, conf)
+    jsonDF.saveToOpenSearch(target, conf)
     RestUtils.refresh(index)
     val hit1 = RestUtils.get(s"$docPath/1")
     val hit2 = RestUtils.get(s"$docPath/2")
@@ -570,7 +570,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val conf = Map("opensearch.mapping.id" -> "id")
     val rdd = sc.makeRDD(data)
     val df = sqc.createDataFrame(rdd, schema)
-    df.saveToEs(target, conf)
+    df.saveToOpenSearch(target, conf)
     RestUtils.refresh(index)
     val hit1 = RestUtils.get(s"$docPath/1")
     val hit2 = RestUtils.get(s"$docPath/2")
@@ -597,7 +597,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val conf = Map("opensearch.mapping.id" -> "id", "opensearch.spark.dataframe.write.null" -> "true")
     val rdd = sc.makeRDD(data)
     val df = sqc.createDataFrame(rdd, schema)
-    df.saveToEs(target, conf)
+    df.saveToOpenSearch(target, conf)
     RestUtils.refresh(index)
     val hit1 = RestUtils.get(s"$docPath/1")
     val hit2 = RestUtils.get(s"$docPath/2")
@@ -740,7 +740,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("sparksql-test-scala-basic-write-rich-mapping-id-mapping")
     val (target, docPath) = makeTargets(index, "data")
-    dataFrame.saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "id"))
+    dataFrame.saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "id"))
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
     assertThat(RestUtils.exists(docPath + "/1"), is(true))
@@ -755,7 +755,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("sparksql-test-decimal-exception")
     val (target, _) = makeTargets(index, "data")
-    dataFrame.saveToEs(target)
+    dataFrame.saveToOpenSearch(target)
   }
 
   @Test
@@ -783,8 +783,8 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
       "opensearch.write.rest.error.handler.opensearch.tags" -> "tagValue"
     )
 
-    dataFrame2.saveToEs(dataTarget, conf)
-    dataFrame1.saveToEs(dataTarget, conf)
+    dataFrame2.saveToOpenSearch(dataTarget, conf)
+    dataFrame1.saveToOpenSearch(dataTarget, conf)
 
     val errorDataSearch = RestUtils.get(errorTarget + "/_search")
     val errorDoc = JsonUtils.query("hits").get("hits").get(0).apply(JsonUtils.asMap(errorDataSearch))
@@ -869,7 +869,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val data = artistsAsDataFrame
     val single = data.where(data("id").equalTo(1))
     assertEquals(1L, single.count())
-    single.saveToEs(target)
+    single.saveToOpenSearch(target)
 
     // Make sure that the scroll limit works with both a shard that has data and a shard that has nothing
     val count = sqc.read.format("opensearch").option("opensearch.scroll.limit", "10").load(target).count()
@@ -908,7 +908,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val trip2 = Map("participants" -> 5, "airport" -> "OTP", "tag" -> "feb", "date" -> "2013-12-28T20:03:10Z")
     val trip3 = Map("participants" -> 3, "airport" -> "MUC OTP SFO JFK", "tag" -> "long", "date" -> "2012-12-28T20:03:10Z")
 
-    sc.makeRDD(Seq(trip1, trip2, trip3)).saveToEs(target)
+    sc.makeRDD(Seq(trip1, trip2, trip3)).saveToOpenSearch(target)
   }
 
   private def opensearchDataSource(table: String) = {
@@ -1191,11 +1191,11 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("spark-test-json-file")
     val (target, docPath) = makeTargets(index, "data")
-    input.saveToEs(target, cfg)
+    input.saveToOpenSearch(target, cfg)
 
     val basic = sqc.read.json(readAsRDD(this.getClass.getResource("/basic.json").toURI()))
     println(basic.schema.simpleString)
-    basic.saveToEs(target, cfg)
+    basic.saveToOpenSearch(target, cfg)
   }
 
   @Test
@@ -1209,7 +1209,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("spark-test-json-file-schema")
     val (target, docPath) = makeTargets(index, "data")
-    input.saveToEs(target, cfg)
+    input.saveToOpenSearch(target, cfg)
 
     val dsCfg = collection.mutable.Map(cfg.toSeq: _*) += ("path" -> target)
     val dfLoad = sqc.read.format("org.opensearch.spark.sql").options(dsCfg.toMap).load
@@ -1284,7 +1284,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("sparksql-test-scala-sql-overwrite")
     val (target, _) = makeTargets(index, "data")
-    srcFrame.saveToEs(target, cfg)
+    srcFrame.saveToOpenSearch(target, cfg)
 
     val table = wrapIndex("table_overwrite")
 
@@ -1379,7 +1379,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val (target, _) = makeTargets(index, "data")
 
     val dstFrame = artistsAsDataFrame
-    dstFrame.saveToEs(target, cfg)
+    dstFrame.saveToOpenSearch(target, cfg)
 
     val srcTable = wrapIndex("table_overwrite_src")
     val dstTable = wrapIndex("table_overwrite_dst")
@@ -1632,8 +1632,8 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
       }
 
-      sc.makeRDD(parents).saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
-      sc.makeRDD(children).saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
+      sc.makeRDD(parents).saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
+      sc.makeRDD(children).saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
 
       assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString("kimchy"))
       assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString(""""_routing":"1""""))
@@ -1667,7 +1667,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
       }
 
-      sc.makeRDD(docs).saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
+      sc.makeRDD(docs).saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
 
       assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString("kimchy"))
       assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString(""""_routing":"1""""))

--- a/spark/sql-20/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchSparkStructuredStreaming.scala
+++ b/spark/sql-20/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchSparkStructuredStreaming.scala
@@ -203,9 +203,9 @@ class AbstractScalaOpenSearchSparkStructuredStreaming(prefix: String, something:
     val target = wrapIndex(resource("failed-on-save-call", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
-    test.stream.saveToEs(target)
+    test.stream.saveToOpenSearch(target)
 
-    Assert.fail("Should not launch job with saveToEs() method")
+    Assert.fail("Should not launch job with saveToOpenSearch() method")
   }
 
   @Test(expected = classOf[OpenSearchHadoopIllegalArgumentException])
@@ -358,7 +358,7 @@ class AbstractScalaOpenSearchSparkStructuredStreaming(prefix: String, something:
       Source.fromFile(s"${checkpointDir(target)}/0").getLines().foreach(println)
 
       assertThat(Files.exists(new File(check).toPath), is(true))
-      assertThat(Files.list(new File(check).toPath).count(), is(2L)) // A UUID for general checkpoint, and one for ES.
+      assertThat(Files.list(new File(check).toPath).count(), is(2L)) // A UUID for general checkpoint, and one for OpenSearch.
     } finally {
       spark.conf.unset(SQLConf.CHECKPOINT_LOCATION.key)
     }

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/deploy/yarn/security/OpenSearchServiceCredentialProvider.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/deploy/yarn/security/OpenSearchServiceCredentialProvider.scala
@@ -108,7 +108,7 @@ class OpenSearchServiceCredentialProvider extends ServiceCredentialProvider {
     val esAuthMethod = settings.getSecurityAuthenticationMethod
     val required = isSecurityEnabled && AuthenticationMethod.KERBEROS.equals(esAuthMethod)
     LOG.info(s"Hadoop Security Enabled = [$isSecurityEnabled]")
-    LOG.info(s"ES Auth Method = [$esAuthMethod]")
+    LOG.info(s"OpenSearch Auth Method = [$esAuthMethod]")
     LOG.info(s"Are creds required = [$required]")
     required
   }

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/sql/DefaultSource.scala
@@ -562,7 +562,7 @@ private[sql] case class OpenSearchRelation(parameters: Map[String, String], @tra
       }
       rr.close()
     }
-    OpenSearchSparkSQL.saveToEs(data, parameters)
+    OpenSearchSparkSQL.saveToOpenSearch(data, parameters)
   }
 
   def isEmpty(): Boolean = {

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/sql/OpenSearchSparkSQL.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/sql/OpenSearchSparkSQL.scala
@@ -87,16 +87,16 @@ object OpenSearchSparkSQL {
   // Write
   //
   
-  def saveToEs(srdd: Dataset[_], resource: String): Unit = {
-    saveToEs(srdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(srdd: Dataset[_], resource: String): Unit = {
+    saveToOpenSearch(srdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(srdd: Dataset[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(srdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(srdd: Dataset[_], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearch(srdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(srdd: Dataset[_], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearch(srdd: Dataset[_], cfg: Map[String, String]): Unit = {
     if (srdd != null) {
       if (srdd.isStreaming) {
-        throw new OpenSearchHadoopIllegalArgumentException("Streaming Datasets should not be saved with 'saveToEs()'. Instead, use " +
+        throw new OpenSearchHadoopIllegalArgumentException("Streaming Datasets should not be saved with 'saveToOpenSearch()'. Instead, use " +
           "the 'writeStream().format(\"opensearch\").save()' methods.")
       }
       val sparkCtx = srdd.sqlContext.sparkContext
@@ -104,7 +104,7 @@ object OpenSearchSparkSQL {
       val esCfg = new PropertiesSettings().load(sparkCfg.save())
       esCfg.merge(cfg.asJava)
 
-      // Need to discover ES Version before checking index existence
+      // Need to discover OpenSearch Version before checking index existence
       InitializationUtils.setUserProviderIfNotSet(esCfg, classOf[HadoopUserProvider], LOG)
       InitializationUtils.discoverClusterInfo(esCfg, LOG)
       InitializationUtils.checkIdForOperation(esCfg)

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/sql/api/java/JavaOpenSearchSparkSQL.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/sql/api/java/JavaOpenSearchSparkSQL.scala
@@ -58,7 +58,7 @@ object JavaOpenSearchSparkSQL {
   def esDF(ss: SparkSession, resource: String, cfg: JMap[String, String]): DataFrame = OpenSearchSparkSQL.esDF(ss, resource, cfg.asScala)
   def esDF(ss: SparkSession, resource: String, query: String, cfg: JMap[String, String]): DataFrame = OpenSearchSparkSQL.esDF(ss, resource, query, cfg.asScala)
 
-  def saveToEs[T](ds: Dataset[T], resource: String): Unit = OpenSearchSparkSQL.saveToEs(ds , resource)
-  def saveToEs[T](ds: Dataset[T], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkSQL.saveToEs(ds, resource, cfg.asScala)
-  def saveToEs[T](ds: Dataset[T], cfg: JMap[String, String]): Unit = OpenSearchSparkSQL.saveToEs(ds, cfg.asScala)
+  def saveToOpenSearch[T](ds: Dataset[T], resource: String): Unit = OpenSearchSparkSQL.saveToOpenSearch(ds , resource)
+  def saveToOpenSearch[T](ds: Dataset[T], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkSQL.saveToOpenSearch(ds, resource, cfg.asScala)
+  def saveToOpenSearch[T](ds: Dataset[T], cfg: JMap[String, String]): Unit = OpenSearchSparkSQL.saveToOpenSearch(ds, cfg.asScala)
 }

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/sql/package.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/sql/package.scala
@@ -55,9 +55,9 @@ package object sql {
   implicit def sparkDataFrameFunctions(df: DataFrame) = new SparkDataFrameFunctions(df)
 
   class SparkDataFrameFunctions(df: DataFrame) extends Serializable {
-    def saveToEs(resource: String): Unit = { OpenSearchSparkSQL.saveToEs(df, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToEs(df, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToEs(df, cfg)    }
+    def saveToOpenSearch(resource: String): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, resource) }
+    def saveToOpenSearch(resource: String, cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, resource, cfg) }
+    def saveToOpenSearch(cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, cfg)    }
   }
   
   implicit def sparkSessionFunctions(ss: SparkSession)= new SparkSessionFunctions(ss)
@@ -74,8 +74,8 @@ package object sql {
   implicit def sparkDatasetFunctions[T : ClassTag](ds: Dataset[T]) = new SparkDatasetFunctions(ds)
   
   class SparkDatasetFunctions[T : ClassTag](ds: Dataset[T]) extends Serializable {
-    def saveToEs(resource: String): Unit =  { OpenSearchSparkSQL.saveToEs(ds, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit =  { OpenSearchSparkSQL.saveToEs(ds, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]): Unit =  { OpenSearchSparkSQL.saveToEs(ds, cfg)    }
+    def saveToOpenSearch(resource: String): Unit =  { OpenSearchSparkSQL.saveToOpenSearch(ds, resource) }
+    def saveToOpenSearch(resource: String, cfg: scala.collection.Map[String, String]): Unit =  { OpenSearchSparkSQL.saveToOpenSearch(ds, resource, cfg) }
+    def saveToOpenSearch(cfg: scala.collection.Map[String, String]): Unit =  { OpenSearchSparkSQL.saveToOpenSearch(ds, cfg)    }
   }
 }

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/sql/streaming/StructuredStreamingVersionLock.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/sql/streaming/StructuredStreamingVersionLock.scala
@@ -58,7 +58,7 @@ object StructuredStreamingVersionLock {
         case _ =>
           throw new OpenSearchHadoopIllegalArgumentException(s"Spark version mismatch. Expected at least Spark version [2.2.0] " +
             s"but found [${session.version}]. Spark Structured Streaming is a feature that is only supported on Spark " +
-            s"[2.2.0] and up for this version of ES-Hadoop/Spark.")
+            s"[2.2.0] and up for this version of OpenSearch-Hadoop/Spark.")
       }
     } catch {
       case e: OpenSearchHadoopException =>

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/streaming/OpenSearchSparkStreaming.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/streaming/OpenSearchSparkStreaming.scala
@@ -41,36 +41,36 @@ import scala.collection.Map
 object OpenSearchSparkStreaming {
 
   // Save methods
-  def saveToEs(ds: DStream[_], resource: String): Unit = {
-    saveToEs(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(ds: DStream[_], resource: String): Unit = {
+    saveToOpenSearch(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearch(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearch(ds: DStream[_], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = false)
   }
 
   // Save with metadata
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String): Unit = {
-    saveToEsWithMeta(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], resource: String): Unit = {
+    saveToOpenSearchWithMeta(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEsWithMeta(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearchWithMeta(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = true)
   }
 
   // Save as JSON
   def saveJsonToEs(ds: DStream[_], resource: String): Unit = {
-    saveToEs(ds, resource, Map(OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, resource, Map(OPENSEARCH_INPUT_JSON -> true.toString))
   }
   def saveJsonToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(ds, resource, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, resource, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
   }
   def saveJsonToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
-    saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
   }
 
   // Implementation

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/streaming/api/java/JavaOpenSearchSparkStreaming.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/streaming/api/java/JavaOpenSearchSparkStreaming.scala
@@ -39,13 +39,13 @@ import org.opensearch.spark.streaming.OpenSearchSparkStreaming
 object JavaOpenSearchSparkStreaming {
 
   // specify the return types to make sure the bytecode is generated properly (w/o any scala.collections in it)
-  def saveToEs(ds: JavaDStream[_], resource: String): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, resource)
-  def saveToEs(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, resource, cfg.asScala)
-  def saveToEs(ds: JavaDStream[_], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, cfg.asScala)
+  def saveToOpenSearch(ds: JavaDStream[_], resource: String): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, resource)
+  def saveToOpenSearch(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, resource, cfg.asScala)
+  def saveToOpenSearch(ds: JavaDStream[_], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, cfg.asScala)
 
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, resource)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, resource, cfg.asScala)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, cfg.asScala)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, resource)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, resource, cfg.asScala)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, cfg.asScala)
 
   def saveJsonToEs(ds: JavaDStream[String], resource: String): Unit = OpenSearchSparkStreaming.saveJsonToEs(ds.dstream, resource)
   def saveJsonToEs(ds: JavaDStream[String], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)

--- a/spark/sql-20/src/main/scala/org/opensearch/spark/streaming/package.scala
+++ b/spark/sql-20/src/main/scala/org/opensearch/spark/streaming/package.scala
@@ -42,9 +42,9 @@ package object streaming {
   implicit def sparkDStreamFunctions(ds: DStream[_]): SparkDStreamFunctions = new SparkDStreamFunctions(ds)
 
   class SparkDStreamFunctions(ds: DStream[_]) extends Serializable {
-    def saveToEs(resource: String): Unit = { OpenSearchSparkStreaming.saveToEs(ds, resource) }
-    def saveToEs(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEs(ds, resource, cfg) }
-    def saveToEs(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEs(ds, cfg) }
+    def saveToOpenSearch(resource: String): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, resource) }
+    def saveToOpenSearch(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, resource, cfg) }
+    def saveToOpenSearch(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, cfg) }
   }
 
   implicit def sparkStringJsonDStreamFunctions(ds: DStream[String]): SparkJsonDStreamFunctions[String] = new SparkJsonDStreamFunctions[String](ds)
@@ -59,9 +59,9 @@ package object streaming {
   implicit def sparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K,V)]): SparkPairDStreamFunctions[K,V] = new SparkPairDStreamFunctions[K,V](ds)
 
   class SparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K, V)]) extends Serializable {
-    def saveToEsWithMeta(resource: String): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, resource) }
-    def saveToEsWithMeta(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, resource, cfg) }
-    def saveToEsWithMeta(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, cfg) }
+    def saveToOpenSearchWithMeta(resource: String): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, resource) }
+    def saveToOpenSearchWithMeta(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, resource, cfg) }
+    def saveToOpenSearchWithMeta(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, cfg) }
   }
 
 }

--- a/spark/sql-30/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkSQLTest.java
+++ b/spark/sql-30/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkSQLTest.java
@@ -118,7 +118,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
         Dataset<Row> dataset = artistsAsDataset();
 
 		String target = resource("sparksql-test-scala-basic-write", "data", version);
-		JavaOpenSearchSparkSQL.saveToEs(dataset, target);
+		JavaOpenSearchSparkSQL.saveToOpenSearch(dataset, target);
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
 	}
@@ -130,7 +130,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
 		String target = resource("sparksql-test-scala-basic-write-id-mapping", "data", version);
 		String docEndpoint = docEndpoint("sparksql-test-scala-basic-write-id-mapping", "data", version);
 
-		JavaOpenSearchSparkSQL.saveToEs(dataset, target,
+		JavaOpenSearchSparkSQL.saveToOpenSearch(dataset, target,
 				ImmutableMap.of(OPENSEARCH_MAPPING_ID, "id"));
 		assertTrue(RestUtils.exists(target));
 		assertThat(RestUtils.get(target + "/_search?"), containsString("345"));
@@ -142,7 +142,7 @@ public class AbstractJavaOpenSearchSparkSQLTest implements Serializable {
         Dataset<Row> dataset = artistsAsDataset();
 
         String target = resource("sparksql-test-scala-basic-write-exclude-mapping", "data", version);
-		JavaOpenSearchSparkSQL.saveToEs(dataset, target,
+		JavaOpenSearchSparkSQL.saveToOpenSearch(dataset, target,
                 ImmutableMap.of(OPENSEARCH_MAPPING_EXCLUDE, "url"));
         assertTrue(RestUtils.exists(target));
         assertThat(RestUtils.get(target + "/_search?"), not(containsString("url")));

--- a/spark/sql-30/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStreamingTest.java
+++ b/spark/sql-30/src/itest/java/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStreamingTest.java
@@ -173,7 +173,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         rddQueue.add(batch);
         JavaInputDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue, true);
         // apply closure
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2); // Let the processing happen
         ssc.stop(false, true);
@@ -205,7 +205,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue, true);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2); // Let the processing happen
         ssc.stop(false, true);
@@ -244,12 +244,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/1"));
         assertTrue(RestUtils.exists(docEndpoint + "/2"));
 
@@ -285,12 +285,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
 
         JavaPairDStream<Integer, Map<String, Object>> metaDstream = dstream.mapToPair(new ExtractIDFunction());
 
-        JavaOpenSearchSparkStreaming.saveToEsWithMeta(metaDstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearchWithMeta(metaDstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/3"));
         assertTrue(RestUtils.exists(docEndpoint + "/4"));
 
@@ -336,12 +336,12 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
 
         JavaPairDStream<Map<Metadata, Object>, Map<String, Object>> metaDstream = dstream.mapToPair(new ExtractMetaMap());
 
-        JavaOpenSearchSparkStreaming.saveToEsWithMeta(metaDstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearchWithMeta(metaDstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
 
-        assertEquals(2, JavaOpenSearchSpark.esRDD(sc, target).count());
+        assertEquals(2, JavaOpenSearchSpark.opensearchRDD(sc, target).count());
         assertTrue(RestUtils.exists(docEndpoint + "/5"));
         assertTrue(RestUtils.exists(docEndpoint + "/6"));
 
@@ -383,7 +383,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
@@ -427,7 +427,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, localConf);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, localConf);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);
@@ -456,7 +456,7 @@ public class AbstractJavaOpenSearchSparkStreamingTest implements Serializable {
         Queue<JavaRDD<Map<String, Object>>> rddQueue = new LinkedList<>();
         rddQueue.add(batch);
         JavaDStream<Map<String, Object>> dstream = ssc.queueStream(rddQueue);
-        JavaOpenSearchSparkStreaming.saveToEs(dstream, target, cfg);
+        JavaOpenSearchSparkStreaming.saveToOpenSearch(dstream, target, cfg);
         ssc.start();
         TimeUnit.SECONDS.sleep(2);
         ssc.stop(false, true);

--- a/spark/sql-30/src/itest/scala/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStructuredStreamingTest.java
+++ b/spark/sql-30/src/itest/scala/org/opensearch/spark/integration/AbstractJavaOpenSearchSparkStructuredStreamingTest.java
@@ -271,7 +271,7 @@ public class AbstractJavaOpenSearchSparkStructuredStreamingTest {
                 target
         );
 
-        assertEquals(3, JavaOpenSearchSpark.esRDD(new JavaSparkContext(spark.sparkContext()), target).count());
+        assertEquals(3, JavaOpenSearchSpark.opensearchRDD(new JavaSparkContext(spark.sparkContext()), target).count());
         assertTrue(RestUtils.exists(docPath + "/1"));
         assertTrue(RestUtils.exists(docPath + "/2"));
         assertTrue(RestUtils.exists(docPath + "/3"));

--- a/spark/sql-30/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchSparkSQL.scala
+++ b/spark/sql-30/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchSparkSQL.scala
@@ -287,7 +287,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
   def testEmptyDataFrame() {
     val index = wrapIndex("spark-test-empty-dataframe")
     val (target, _) = makeTargets(index, "data")
-    val idx = sqc.emptyDataFrame.saveToEs(target)
+    val idx = sqc.emptyDataFrame.saveToOpenSearch(target)
   }
 
   @Test(expected = classOf[OpenSearchHadoopIllegalArgumentException])
@@ -295,7 +295,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val newCfg = collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INDEX_AUTO_CREATE -> "no")
     val index = wrapIndex("spark-test-non-existing-empty-dataframe")
     val (target, _) = makeTargets(index, "data")
-    val idx = sqc.emptyDataFrame.saveToEs(target, newCfg)
+    val idx = sqc.emptyDataFrame.saveToOpenSearch(target, newCfg)
   }
 
   @Test
@@ -463,7 +463,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val trip1 = Map("%s" -> "special")
 
-    sc.makeRDD(Seq(trip1)).saveToEs(target)
+    sc.makeRDD(Seq(trip1)).saveToOpenSearch(target)
   }
   
   @Test
@@ -479,7 +479,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("sparksql-test-scala-basic-write")
     val (target, _) = makeTargets(index, "data")
-    dataFrame.saveToEs(target, cfg)
+    dataFrame.saveToOpenSearch(target, cfg)
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
   }
@@ -501,7 +501,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val (target, docPath) = makeTargets(index, "data")
     val newCfg = collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_EXCLUDE -> "url")
 
-    dataFrame.saveToEs(target, newCfg)
+    dataFrame.saveToOpenSearch(target, newCfg)
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
     assertThat(RestUtils.exists(docPath + "/1"), is(true))
@@ -521,7 +521,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val conf = Map(OPENSEARCH_MAPPING_ID -> "id")
     val rdd = sc.makeRDD(docs)
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
-    jsonDF.saveToEs(target, conf)
+    jsonDF.saveToOpenSearch(target, conf)
     RestUtils.refresh(index)
     val hit1 = RestUtils.get(s"$docPath/1")
     val hit2 = RestUtils.get(s"$docPath/2")
@@ -543,7 +543,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val conf = Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_SPARK_DATAFRAME_WRITE_NULL_VALUES -> "true")
     val rdd = sc.makeRDD(docs)
     val jsonDF = sqc.read.json(rdd).toDF.select("id", "name")
-    jsonDF.saveToEs(target, conf)
+    jsonDF.saveToOpenSearch(target, conf)
     RestUtils.refresh(index)
     val hit1 = RestUtils.get(s"$docPath/1")
     val hit2 = RestUtils.get(s"$docPath/2")
@@ -572,7 +572,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val conf = Map("opensearch.mapping.id" -> "id")
     val rdd = sc.makeRDD(data)
     val df = sqc.createDataFrame(rdd, schema)
-    df.saveToEs(target, conf)
+    df.saveToOpenSearch(target, conf)
     RestUtils.refresh(index)
     val hit1 = RestUtils.get(s"$docPath/1")
     val hit2 = RestUtils.get(s"$docPath/2")
@@ -599,7 +599,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val conf = Map("opensearch.mapping.id" -> "id", "opensearch.spark.dataframe.write.null" -> "true")
     val rdd = sc.makeRDD(data)
     val df = sqc.createDataFrame(rdd, schema)
-    df.saveToEs(target, conf)
+    df.saveToOpenSearch(target, conf)
     RestUtils.refresh(index)
     val hit1 = RestUtils.get(s"$docPath/1")
     val hit2 = RestUtils.get(s"$docPath/2")
@@ -742,7 +742,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("sparksql-test-scala-basic-write-rich-mapping-id-mapping")
     val (target, docPath) = makeTargets(index, "data")
-    dataFrame.saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "id"))
+    dataFrame.saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "id"))
     assertTrue(RestUtils.exists(target))
     assertThat(RestUtils.get(target + "/_search?"), containsString("345"))
     assertThat(RestUtils.exists(docPath + "/1"), is(true))
@@ -757,7 +757,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("sparksql-test-decimal-exception")
     val (target, _) = makeTargets(index, "data")
-    dataFrame.saveToEs(target)
+    dataFrame.saveToOpenSearch(target)
   }
 
   @Test
@@ -785,8 +785,8 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
       "opensearch.write.rest.error.handler.opensearch.tags" -> "tagValue"
     )
 
-    dataFrame2.saveToEs(dataTarget, conf)
-    dataFrame1.saveToEs(dataTarget, conf)
+    dataFrame2.saveToOpenSearch(dataTarget, conf)
+    dataFrame1.saveToOpenSearch(dataTarget, conf)
 
     val errorDataSearch = RestUtils.get(errorTarget + "/_search")
     val errorDoc = JsonUtils.query("hits").get("hits").get(0).apply(JsonUtils.asMap(errorDataSearch))
@@ -871,7 +871,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val data = artistsAsDataFrame
     val single = data.where(data("id").equalTo(1))
     assertEquals(1L, single.count())
-    single.saveToEs(target)
+    single.saveToOpenSearch(target)
 
     // Make sure that the scroll limit works with both a shard that has data and a shard that has nothing
     val count = sqc.read.format("opensearch").option("opensearch.scroll.limit", "10").load(target).count()
@@ -910,7 +910,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val trip2 = Map("participants" -> 5, "airport" -> "OTP", "tag" -> "feb", "date" -> "2013-12-28T20:03:10Z")
     val trip3 = Map("participants" -> 3, "airport" -> "MUC OTP SFO JFK", "tag" -> "long", "date" -> "2012-12-28T20:03:10Z")
 
-    sc.makeRDD(Seq(trip1, trip2, trip3)).saveToEs(target)
+    sc.makeRDD(Seq(trip1, trip2, trip3)).saveToOpenSearch(target)
   }
 
   private def opensearchDataSource(table: String) = {
@@ -1193,11 +1193,11 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("spark-test-json-file")
     val (target, docPath) = makeTargets(index, "data")
-    input.saveToEs(target, cfg)
+    input.saveToOpenSearch(target, cfg)
 
     val basic = sqc.read.json(readAsRDD(this.getClass.getResource("/basic.json").toURI()))
     println(basic.schema.simpleString)
-    basic.saveToEs(target, cfg)
+    basic.saveToOpenSearch(target, cfg)
   }
 
   @Test
@@ -1211,7 +1211,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("spark-test-json-file-schema")
     val (target, docPath) = makeTargets(index, "data")
-    input.saveToEs(target, cfg)
+    input.saveToOpenSearch(target, cfg)
 
     val dsCfg = collection.mutable.Map(cfg.toSeq: _*) += ("path" -> target)
     val dfLoad = sqc.read.format("org.opensearch.spark.sql").options(dsCfg.toMap).load
@@ -1286,7 +1286,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
 
     val index = wrapIndex("sparksql-test-scala-sql-overwrite")
     val (target, _) = makeTargets(index, "data")
-    srcFrame.saveToEs(target, cfg)
+    srcFrame.saveToOpenSearch(target, cfg)
 
     val table = wrapIndex("table_overwrite")
 
@@ -1381,7 +1381,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
     val (target, _) = makeTargets(index, "data")
 
     val dstFrame = artistsAsDataFrame
-    dstFrame.saveToEs(target, cfg)
+    dstFrame.saveToOpenSearch(target, cfg)
 
     val srcTable = wrapIndex("table_overwrite_src")
     val dstTable = wrapIndex("table_overwrite_dst")
@@ -1634,8 +1634,8 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
       }
 
-      sc.makeRDD(parents).saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
-      sc.makeRDD(children).saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
+      sc.makeRDD(parents).saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
+      sc.makeRDD(children).saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
 
       assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString("kimchy"))
       assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString(""""_routing":"1""""))
@@ -1669,7 +1669,7 @@ class AbstractScalaOpenSearchScalaSparkSQL(prefix: String, readMetadata: jl.Bool
         RestUtils.putMapping(index, typename, "data/join/mapping/typed.json")
       }
 
-      sc.makeRDD(docs).saveToEs(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
+      sc.makeRDD(docs).saveToOpenSearch(target, Map(OPENSEARCH_MAPPING_ID -> "id", OPENSEARCH_MAPPING_JOIN -> "joiner"))
 
       assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString("kimchy"))
       assertThat(RestUtils.get(docPath + "/10?routing=1"), containsString(""""_routing":"1""""))

--- a/spark/sql-30/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchSparkStructuredStreaming.scala
+++ b/spark/sql-30/src/itest/scala/org/opensearch/spark/integration/AbstractScalaOpenSearchSparkStructuredStreaming.scala
@@ -203,9 +203,9 @@ class AbstractScalaOpenSearchSparkStructuredStreaming(prefix: String, something:
     val target = wrapIndex(resource("failed-on-save-call", "data", version))
     val test = new StreamingQueryTestHarness[Record](spark)
 
-    test.stream.saveToEs(target)
+    test.stream.saveToOpenSearch(target)
 
-    Assert.fail("Should not launch job with saveToEs() method")
+    Assert.fail("Should not launch job with saveToOpenSearch() method")
   }
 
   @Test(expected = classOf[OpenSearchHadoopIllegalArgumentException])
@@ -358,7 +358,7 @@ class AbstractScalaOpenSearchSparkStructuredStreaming(prefix: String, something:
       Source.fromFile(s"${checkpointDir(target)}/0").getLines().foreach(println)
 
       assertThat(Files.exists(new File(check).toPath), is(true))
-      assertThat(Files.list(new File(check).toPath).count(), is(2L)) // A UUID for general checkpoint, and one for ES.
+      assertThat(Files.list(new File(check).toPath).count(), is(2L)) // A UUID for general checkpoint, and one for OpenSearch.
     } finally {
       spark.conf.unset(SQLConf.CHECKPOINT_LOCATION.key)
     }

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/deploy/yarn/security/OpenSearchServiceCredentialProvider.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/deploy/yarn/security/OpenSearchServiceCredentialProvider.scala
@@ -97,7 +97,7 @@ class OpenSearchServiceCredentialProvider extends HadoopDelegationTokenProvider 
     val esAuthMethod = settings.getSecurityAuthenticationMethod
     val required = isSecurityEnabled && AuthenticationMethod.KERBEROS.equals(esAuthMethod)
     LOG.info(s"Hadoop Security Enabled = [$isSecurityEnabled]")
-    LOG.info(s"ES Auth Method = [$esAuthMethod]")
+    LOG.info(s"OpenSearch Auth Method = [$esAuthMethod]")
     LOG.info(s"Are creds required = [$required]")
     required
   }

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/deploy/yarn/security/OpenSearchServiceCredentialProvider.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/deploy/yarn/security/OpenSearchServiceCredentialProvider.scala
@@ -75,7 +75,7 @@ class OpenSearchServiceCredentialProvider extends HadoopDelegationTokenProvider 
    * spark.security.credentials.[serviceName].enabled
    * @return the service name this provider corresponds to
    */
-  override def serviceName: String = "elasticsearch"
+  override def serviceName: String = "opensearch"
 
   /**
    * Given a configuration, check to see if tokens would be required.

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/sql/DefaultSource.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/sql/DefaultSource.scala
@@ -560,7 +560,7 @@ private[sql] case class OpenSearchRelation(parameters: Map[String, String], @tra
       }
       rr.close()
     }
-    OpenSearchSparkSQL.saveToEs(data, parameters)
+    OpenSearchSparkSQL.saveToOpenSearch(data, parameters)
   }
 
   def isEmpty(): Boolean = {

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/sql/OpenSearchSparkSQL.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/sql/OpenSearchSparkSQL.scala
@@ -87,16 +87,16 @@ object OpenSearchSparkSQL {
   // Write
   //
   
-  def saveToEs(srdd: Dataset[_], resource: String): Unit = {
-    saveToEs(srdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(srdd: Dataset[_], resource: String): Unit = {
+    saveToOpenSearch(srdd, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(srdd: Dataset[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(srdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(srdd: Dataset[_], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearch(srdd, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(srdd: Dataset[_], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearch(srdd: Dataset[_], cfg: Map[String, String]): Unit = {
     if (srdd != null) {
       if (srdd.isStreaming) {
-        throw new OpenSearchHadoopIllegalArgumentException("Streaming Datasets should not be saved with 'saveToEs()'. Instead, use " +
+        throw new OpenSearchHadoopIllegalArgumentException("Streaming Datasets should not be saved with 'saveToOpenSearch()'. Instead, use " +
           "the 'writeStream().format(\"opensearch\").save()' methods.")
       }
       val sparkCtx = srdd.sqlContext.sparkContext
@@ -104,7 +104,7 @@ object OpenSearchSparkSQL {
       val esCfg = new PropertiesSettings().load(sparkCfg.save())
       esCfg.merge(cfg.asJava)
 
-      // Need to discover ES Version before checking index existence
+      // Need to discover OpenSearch Version before checking index existence
       InitializationUtils.setUserProviderIfNotSet(esCfg, classOf[HadoopUserProvider], LOG)
       InitializationUtils.discoverClusterInfo(esCfg, LOG)
       InitializationUtils.checkIdForOperation(esCfg)

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/sql/api/java/JavaOpenSearchSparkSQL.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/sql/api/java/JavaOpenSearchSparkSQL.scala
@@ -56,7 +56,7 @@ object JavaOpenSearchSparkSQL {
   def esDF(ss: SparkSession, resource: String, cfg: JMap[String, String]): DataFrame = OpenSearchSparkSQL.esDF(ss, resource, cfg.asScala)
   def esDF(ss: SparkSession, resource: String, query: String, cfg: JMap[String, String]): DataFrame = OpenSearchSparkSQL.esDF(ss, resource, query, cfg.asScala)
 
-  def saveToEs[T](ds: Dataset[T], resource: String): Unit = OpenSearchSparkSQL.saveToEs(ds , resource)
-  def saveToEs[T](ds: Dataset[T], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkSQL.saveToEs(ds, resource, cfg.asScala)
-  def saveToEs[T](ds: Dataset[T], cfg: JMap[String, String]): Unit = OpenSearchSparkSQL.saveToEs(ds, cfg.asScala)
+  def saveToOpenSearch[T](ds: Dataset[T], resource: String): Unit = OpenSearchSparkSQL.saveToOpenSearch(ds , resource)
+  def saveToOpenSearch[T](ds: Dataset[T], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkSQL.saveToOpenSearch(ds, resource, cfg.asScala)
+  def saveToOpenSearch[T](ds: Dataset[T], cfg: JMap[String, String]): Unit = OpenSearchSparkSQL.saveToOpenSearch(ds, cfg.asScala)
 }

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/sql/package.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/sql/package.scala
@@ -55,9 +55,9 @@ package object sql {
   implicit def sparkDataFrameFunctions(df: DataFrame) = new SparkDataFrameFunctions(df)
 
   class SparkDataFrameFunctions(df: DataFrame) extends Serializable {
-    def saveToEs(resource: String): Unit = { OpenSearchSparkSQL.saveToEs(df, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToEs(df, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToEs(df, cfg)    }
+    def saveToOpenSearch(resource: String): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, resource) }
+    def saveToOpenSearch(resource: String, cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, resource, cfg) }
+    def saveToOpenSearch(cfg: scala.collection.Map[String, String]): Unit = { OpenSearchSparkSQL.saveToOpenSearch(df, cfg)    }
   }
   
   implicit def sparkSessionFunctions(ss: SparkSession)= new SparkSessionFunctions(ss)
@@ -74,8 +74,8 @@ package object sql {
   implicit def sparkDatasetFunctions[T : ClassTag](ds: Dataset[T]) = new SparkDatasetFunctions(ds)
   
   class SparkDatasetFunctions[T : ClassTag](ds: Dataset[T]) extends Serializable {
-    def saveToEs(resource: String): Unit =  { OpenSearchSparkSQL.saveToEs(ds, resource) }
-    def saveToEs(resource: String, cfg: scala.collection.Map[String, String]): Unit =  { OpenSearchSparkSQL.saveToEs(ds, resource, cfg) }
-    def saveToEs(cfg: scala.collection.Map[String, String]): Unit =  { OpenSearchSparkSQL.saveToEs(ds, cfg)    }
+    def saveToOpenSearch(resource: String): Unit =  { OpenSearchSparkSQL.saveToOpenSearch(ds, resource) }
+    def saveToOpenSearch(resource: String, cfg: scala.collection.Map[String, String]): Unit =  { OpenSearchSparkSQL.saveToOpenSearch(ds, resource, cfg) }
+    def saveToOpenSearch(cfg: scala.collection.Map[String, String]): Unit =  { OpenSearchSparkSQL.saveToOpenSearch(ds, cfg)    }
   }
 }

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/sql/streaming/StructuredStreamingVersionLock.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/sql/streaming/StructuredStreamingVersionLock.scala
@@ -58,7 +58,7 @@ object StructuredStreamingVersionLock {
         case _ =>
           throw new OpenSearchHadoopIllegalArgumentException(s"Spark version mismatch. Expected at least Spark version [2.2.0] " +
             s"but found [${session.version}]. Spark Structured Streaming is a feature that is only supported on Spark " +
-            s"[2.2.0] and up for this version of ES-Hadoop/Spark.")
+            s"[2.2.0] and up for this version of OpenSearch-Hadoop/Spark.")
       }
     } catch {
       case e: OpenSearchHadoopException =>

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/streaming/OpenSearchSparkStreaming.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/streaming/OpenSearchSparkStreaming.scala
@@ -41,36 +41,36 @@ import scala.collection.Map
 object OpenSearchSparkStreaming {
 
   // Save methods
-  def saveToEs(ds: DStream[_], resource: String): Unit = {
-    saveToEs(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(ds: DStream[_], resource: String): Unit = {
+    saveToOpenSearch(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearch(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearch(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearch(ds: DStream[_], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = false)
   }
 
   // Save with metadata
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String): Unit = {
-    saveToEsWithMeta(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], resource: String): Unit = {
+    saveToOpenSearchWithMeta(ds, Map(OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEsWithMeta(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], resource: String, cfg: Map[String, String]): Unit = {
+    saveToOpenSearchWithMeta(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_RESOURCE_WRITE -> resource))
   }
-  def saveToEsWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]): Unit = {
+  def saveToOpenSearchWithMeta[K,V](ds: DStream[(K,V)], cfg: Map[String, String]): Unit = {
     doSaveToEs(ds, cfg, hasMeta = true)
   }
 
   // Save as JSON
   def saveJsonToEs(ds: DStream[_], resource: String): Unit = {
-    saveToEs(ds, resource, Map(OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, resource, Map(OPENSEARCH_INPUT_JSON -> true.toString))
   }
   def saveJsonToEs(ds: DStream[_], resource: String, cfg: Map[String, String]): Unit = {
-    saveToEs(ds, resource, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, resource, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
   }
   def saveJsonToEs(ds: DStream[_], cfg: Map[String, String]): Unit = {
-    saveToEs(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
+    saveToOpenSearch(ds, collection.mutable.Map(cfg.toSeq: _*) += (OPENSEARCH_INPUT_JSON -> true.toString))
   }
 
   // Implementation

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/streaming/api/java/JavaOpenSearchSparkStreaming.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/streaming/api/java/JavaOpenSearchSparkStreaming.scala
@@ -39,13 +39,13 @@ import org.opensearch.spark.streaming.OpenSearchSparkStreaming
 object JavaOpenSearchSparkStreaming {
 
   // specify the return types to make sure the bytecode is generated properly (w/o any scala.collections in it)
-  def saveToEs(ds: JavaDStream[_], resource: String): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, resource)
-  def saveToEs(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, resource, cfg.asScala)
-  def saveToEs(ds: JavaDStream[_], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEs(ds.dstream, cfg.asScala)
+  def saveToOpenSearch(ds: JavaDStream[_], resource: String): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, resource)
+  def saveToOpenSearch(ds: JavaDStream[_], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, resource, cfg.asScala)
+  def saveToOpenSearch(ds: JavaDStream[_], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearch(ds.dstream, cfg.asScala)
 
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, resource)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, resource, cfg.asScala)
-  def saveToEsWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToEsWithMeta(ds.dstream, cfg.asScala)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, resource)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, resource, cfg.asScala)
+  def saveToOpenSearchWithMeta[K, V](ds: JavaPairDStream[K, V], cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds.dstream, cfg.asScala)
 
   def saveJsonToEs(ds: JavaDStream[String], resource: String): Unit = OpenSearchSparkStreaming.saveJsonToEs(ds.dstream, resource)
   def saveJsonToEs(ds: JavaDStream[String], resource: String, cfg: JMap[String, String]): Unit = OpenSearchSparkStreaming.saveJsonToEs(ds.dstream, resource, cfg.asScala)

--- a/spark/sql-30/src/main/scala/org/opensearch/spark/streaming/package.scala
+++ b/spark/sql-30/src/main/scala/org/opensearch/spark/streaming/package.scala
@@ -42,9 +42,9 @@ package object streaming {
   implicit def sparkDStreamFunctions(ds: DStream[_]): SparkDStreamFunctions = new SparkDStreamFunctions(ds)
 
   class SparkDStreamFunctions(ds: DStream[_]) extends Serializable {
-    def saveToEs(resource: String): Unit = { OpenSearchSparkStreaming.saveToEs(ds, resource) }
-    def saveToEs(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEs(ds, resource, cfg) }
-    def saveToEs(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEs(ds, cfg) }
+    def saveToOpenSearch(resource: String): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, resource) }
+    def saveToOpenSearch(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, resource, cfg) }
+    def saveToOpenSearch(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearch(ds, cfg) }
   }
 
   implicit def sparkStringJsonDStreamFunctions(ds: DStream[String]): SparkJsonDStreamFunctions[String] = new SparkJsonDStreamFunctions[String](ds)
@@ -59,9 +59,9 @@ package object streaming {
   implicit def sparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K,V)]): SparkPairDStreamFunctions[K,V] = new SparkPairDStreamFunctions[K,V](ds)
 
   class SparkPairDStreamFunctions[K : ClassTag, V : ClassTag](ds: DStream[(K, V)]) extends Serializable {
-    def saveToEsWithMeta(resource: String): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, resource) }
-    def saveToEsWithMeta(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, resource, cfg) }
-    def saveToEsWithMeta(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToEsWithMeta(ds, cfg) }
+    def saveToOpenSearchWithMeta(resource: String): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, resource) }
+    def saveToOpenSearchWithMeta(resource: String, cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, resource, cfg) }
+    def saveToOpenSearchWithMeta(cfg: Map[String, String]): Unit = { OpenSearchSparkStreaming.saveToOpenSearchWithMeta(ds, cfg) }
   }
 
 }

--- a/storm/src/itest/java/org/opensearch/integration/storm/TestBolt.java
+++ b/storm/src/itest/java/org/opensearch/integration/storm/TestBolt.java
@@ -57,7 +57,7 @@ public class TestBolt implements IRichBolt {
 
     @Override
     public void execute(Tuple input) {
-        // cleanup first to make sure the connection to ES is closed before the test suite shuts down
+        // cleanup first to make sure the connection to OpenSearch is closed before the test suite shuts down
 
         if (done) {
             return;

--- a/storm/src/main/java/org/opensearch/storm/OpenSearchBolt.java
+++ b/storm/src/main/java/org/opensearch/storm/OpenSearchBolt.java
@@ -191,7 +191,7 @@ public class OpenSearchBolt implements IRichBolt {
 
         for (int index = 0; index < inflightTuples.size(); index++) {
             Tuple tuple = inflightTuples.get(index);
-            // bit set means the entry hasn't been removed and thus wasn't written to ES
+            // bit set means the entry hasn't been removed and thus wasn't written to OpenSearch
             if (flush.get(index)) {
                 collector.fail(tuple);
             }

--- a/storm/src/main/java/org/opensearch/storm/security/AutoOpenSearch.java
+++ b/storm/src/main/java/org/opensearch/storm/security/AutoOpenSearch.java
@@ -212,7 +212,7 @@ public class AutoOpenSearch implements IAutoCredentials, ICredentialsRenewer, IN
 
             if (currentTime > expiration) {
                 // Token is already expired, just renew it.
-                LOG.debug("ES Token expired. Renewing token...");
+                LOG.debug("OpenSearch Token expired. Renewing token...");
                 populateCredentials(credentials, topologyConf, topologyOwnerPrincipal);
                 return;
             }
@@ -231,7 +231,7 @@ public class AutoOpenSearch implements IAutoCredentials, ICredentialsRenewer, IN
 
             if (nextRenewal > expiration) {
                 // Token will expire by the next renewal window. Do the renewal
-                LOG.debug("ES Token will expire before next renewal window. Renewing token...");
+                LOG.debug("OpenSearch Token will expire before next renewal window. Renewing token...");
                 populateCredentials(credentials, topologyConf, topologyOwnerPrincipal);
                 return;
             }

--- a/test/fixtures/minikdc/src/main/java/org/opensearch/hadoop/test/fixture/minikdc/MiniKdcFixture.java
+++ b/test/fixtures/minikdc/src/main/java/org/opensearch/hadoop/test/fixture/minikdc/MiniKdcFixture.java
@@ -94,7 +94,7 @@ public class MiniKdcFixture {
         kdcConf.setProperty(MiniKdc.DEBUG, "false"); // Sets krb library debug
         kdcConf.setProperty(MiniKdc.INSTANCE, "DefaultKrbServer");
         kdcConf.setProperty(MiniKdc.TRANSPORT, "TCP");
-        // ES-Hadoop Project Specific Defaults
+        // OpenSearch-Hadoop Project Specific Defaults
         kdcConf.setProperty(MiniKdc.ORG_NAME, "BUILD.CI.OPENSEARCH"); // used to make REALM
         kdcConf.setProperty(MiniKdc.ORG_DOMAIN, "ORG"); // used to make REALM
 

--- a/test/shared/src/main/java/org/opensearch/hadoop/Provisioner.java
+++ b/test/shared/src/main/java/org/opensearch/hadoop/Provisioner.java
@@ -49,7 +49,7 @@ public abstract class Provisioner {
     public static final String SYS_PROP_JOB_JAR = "opensearch.hadoop.job.jar";
 
     static {
-        // init ES-Hadoop JAR
+        // init OpenSearch-Hadoop JAR
         // expect the jar under build\libs
         try {
             String jobJarLocation = System.getProperty(SYS_PROP_JOB_JAR);


### PR DESCRIPTION
Refactors more legacy naming to the OpenSearch namespace and naming conventions.