### PR TITLE
Revert "Bump com.fasterxml.jackson.core:jackson-annotations from 2.6.7 to 2.14.2 in /spark/sql-30"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `commons-codec:commons-codec` from 1.4 to 1.15
 - Bumps `org.json4s:json4s-ast_2.10` from 3.2.10 to 3.6.12
 - Bumps `com.fasterxml.jackson.core:jackson-databind` from 2.7.8 to 2.14.2
-- Bumps `com.fasterxml.jackson.core:jackson-annotations` from 2.6.7 to 2.14.2
 
 
 [Unreleased]: https://github.com/opensearch-project/opensearch-hadoop/compare/main...HEAD

--- a/spark/sql-30/build.gradle
+++ b/spark/sql-30/build.gradle
@@ -78,7 +78,7 @@ sparkVariants {
 
             // Scala compiler needs these for arcane reasons, but they are not used in the api nor the runtime
             add(variant.configuration('compileOnly'), "org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.0.0")
-            add(variant.configuration('compileOnly'), "com.fasterxml.jackson.core:jackson-annotations:2.14.2")
+            add(variant.configuration('compileOnly'), "com.fasterxml.jackson.core:jackson-annotations:2.6.7")
             add(variant.configuration('compileOnly'), "org.json4s:json4s-jackson_${variant.scalaMajorVersion}:3.6.6")
             add(variant.configuration('compileOnly'), "org.json4s:json4s-ast_${variant.scalaMajorVersion}:3.6.6")
             add(variant.configuration('compileOnly'), "org.apache.spark:spark-tags_${variant.scalaMajorVersion}:$variant.sparkVersion")


### PR DESCRIPTION
Reverts opensearch-project/opensearch-hadoop#61