### PR TITLE
Fixes imports from being thirdparty to local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,22 @@
 # CHANGELOG
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-
 ## [Unreleased]
+
+### Added
+
+### Dependencies
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+- Fixes imports from being thirdparty to local ([#245](https://github.com/opensearch-project/opensearch-java/pull/245))
+
+### Security
+## [1.0.0] - 05/18/2023
 ### Added
 - Added CHANGELOG and verifier workflow ([65](https://github.com/opensearch-project/opensearch-hadoop/pull/65))
 - Added snapshot publication workflow ([218](https://github.com/opensearch-project/opensearch-hadoop/pull/218))
@@ -39,4 +54,5 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.json4s:json4s-jackson_2.12` from 3.2.11 to 4.0.6
 - Bumps `org.apache.avro:avro` from 1.7.7 to 1.11.1
 
-[Unreleased]: https://github.com/opensearch-project/opensearch-hadoop/compare/main...HEAD
+[Unreleased]: https://github.com/opensearch-project/opensearch-hadoop/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/opensearch-project/opensearch-hadoop/compare/v7.13.4...v1.0.0

--- a/mr/src/main/java/org/opensearch/hadoop/serialization/dto/mapping/Field.java
+++ b/mr/src/main/java/org/opensearch/hadoop/serialization/dto/mapping/Field.java
@@ -35,8 +35,8 @@ import java.util.Objects;
 
 import org.opensearch.hadoop.serialization.FieldType;
 
-import com.amazonaws.thirdparty.jackson.annotation.JsonCreator;
-import com.amazonaws.thirdparty.jackson.annotation.JsonProperty;
+import org.opensearch.hadoop.thirdparty.codehaus.jackson.annotate.JsonCreator;
+import org.opensearch.hadoop.thirdparty.codehaus.jackson.annotate.JsonProperty;
 
 @SuppressWarnings("serial")
 public class Field implements Serializable {

--- a/mr/src/main/java/org/opensearch/hadoop/serialization/dto/mapping/Mapping.java
+++ b/mr/src/main/java/org/opensearch/hadoop/serialization/dto/mapping/Mapping.java
@@ -41,8 +41,8 @@ import java.util.Map;
 import org.opensearch.hadoop.serialization.FieldType;
 import org.opensearch.hadoop.serialization.field.FieldFilter;
 
-import com.amazonaws.thirdparty.jackson.annotation.JsonCreator;
-import com.amazonaws.thirdparty.jackson.annotation.JsonProperty;
+import org.opensearch.hadoop.thirdparty.codehaus.jackson.annotate.JsonCreator;
+import org.opensearch.hadoop.thirdparty.codehaus.jackson.annotate.JsonProperty;
 
 import java.util.Objects;
 

--- a/mr/src/main/java/org/opensearch/hadoop/util/IOUtils.java
+++ b/mr/src/main/java/org/opensearch/hadoop/util/IOUtils.java
@@ -50,10 +50,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opensearch.hadoop.OpenSearchHadoopIllegalArgumentException;
 import org.opensearch.hadoop.serialization.OpenSearchHadoopSerializationException;
-
-import com.amazonaws.thirdparty.jackson.core.JsonProcessingException;
-import com.amazonaws.thirdparty.jackson.databind.ObjectMapper;
-import com.amazonaws.thirdparty.jackson.databind.SerializationFeature;
+import org.opensearch.hadoop.thirdparty.codehaus.jackson.map.ObjectMapper;
+import org.opensearch.hadoop.thirdparty.codehaus.jackson.map.SerializationConfig;
 
 
 
@@ -63,7 +61,7 @@ import com.amazonaws.thirdparty.jackson.databind.SerializationFeature;
 public abstract class IOUtils {
 
     private final static Field BYTE_ARRAY_BUFFER;
-    static final ObjectMapper mapper = new ObjectMapper().configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    static final ObjectMapper mapper = new ObjectMapper().configure(SerializationConfig.Feature.FAIL_ON_EMPTY_BEANS, false);
 
     private static final Log log = LogFactory.getLog(IOUtils.class);
     private final boolean trace = log.isTraceEnabled();
@@ -94,7 +92,7 @@ public abstract class IOUtils {
         final T object;
             try {
                 object =  mapper.readValue(data, clazz);
-            } catch (JsonProcessingException e) {
+            } catch (IOException e) {
                 throw new OpenSearchHadoopSerializationException("Cannot deserialize string " + data, e);
 
             }

--- a/mr/src/main/java/org/opensearch/hadoop/util/SettingsUtils.java
+++ b/mr/src/main/java/org/opensearch/hadoop/util/SettingsUtils.java
@@ -37,7 +37,6 @@ import org.opensearch.hadoop.serialization.dto.NodeInfo;
 import org.opensearch.hadoop.serialization.field.FieldFilter;
 import org.opensearch.hadoop.serialization.field.FieldFilter.NumberedInclude;
 
-import com.amazonaws.thirdparty.jackson.core.JsonProcessingException;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;


### PR DESCRIPTION
### Description
The imports that certain classes were using were coming from a third party jar that is not bundled in the client. This ensures that the thirdparty libraries are coming from the shaded JAR itself.

### Issues Resolved
Closes #243 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
