### PR TITLE
Updating maintainers to include Xtansia

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @nknize @harshavamsi
+*   @nknize @harshavamsi @Xtansia

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,3 +8,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | -------------------- | --------------------------------------------- | ----------- |
 | Nick Knize           | [nknize](https://github.com/nknize)           | Amazon      |
 | Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
+| Thomas Farr          | [Xtansia](https://github.com/Xtansia)         | Amazon      |


### PR DESCRIPTION
### Description
Adds @Xtansia to the maintainers list. 

Xtansia recently committed https://github.com/opensearch-project/opensearch-hadoop/pull/350 which was a very helpful fix.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
