### PR TITLE
Fix artifact names (post Gradle to 8.5 update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `org.json4s:json4s-jackson_2.12` from 4.0.6 to 4.0.7
 
 ### Changed
-- Update Gradle to 8.5 ([#377](https://github.com/opensearch-project/opensearch-hadoop/pull/377))
+- Update Gradle to 8.5 ([#377](https://github.com/opensearch-project/opensearch-hadoop/pull/377), [#386](https://github.com/opensearch-project/opensearch-hadoop/pull/386))
 
 ### Deprecated
 

--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/BuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/BuildPlugin.groovy
@@ -679,7 +679,7 @@ class BuildPlugin implements Plugin<Project>  {
         // Set the pom's destination to the distribution directory
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
-                pom.destination = project.provider({"${project.buildDir}/poms/${project.base.archivesName}-${project.getVersion()}.pom"})
+                pom.destination = project.provider({"${project.buildDir}/poms/${project.base.archivesName.get()}-${project.getVersion()}.pom"})
             }
         }
 
@@ -738,7 +738,7 @@ class BuildPlugin implements Plugin<Project>  {
     private static void updateVariantPomLocationAndArtifactId(Project project, MavenPublication publication, SparkVariant variant) {
         // Add variant classifier to the pom file name if required
         String classifier = variant.shouldClassifySparkVersion() && variant.isDefaultVariant() == false ? "-${variant.getName()}" : ''
-        String filename = "${project.base.archivesName}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
+        String filename = "${project.base.archivesName.get()}_${variant.scalaMajorVersion}-${project.getVersion()}${classifier}"
         // Fix the pom name
         project.tasks.withType(GenerateMavenPom).all { GenerateMavenPom pom ->
             if (pom.name == "generatePomFileFor${publication.name.capitalize()}Publication") {
@@ -749,7 +749,7 @@ class BuildPlugin implements Plugin<Project>  {
         publication.getPom().withXml { XmlProvider xml ->
             Node root = xml.asNode()
             Node artifactId = (root.get('artifactId') as NodeList).get(0) as Node
-            artifactId.setValue("${project.base.archivesName}_${variant.scalaMajorVersion}")
+            artifactId.setValue("${project.base.archivesName.get()}_${variant.scalaMajorVersion}")
         }
     }
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -145,7 +145,7 @@ publishing {
                 repository.appendNode('url', 'https://clojars.org/repo')
 
                 // Correct the artifact Id, otherwise it is listed as 'dist'
-                root.get('artifactId').get(0).setValue(project.base.archivesName)
+                root.get('artifactId').get(0).setValue(project.base.archivesName.get())
             }
         }
     }


### PR DESCRIPTION
### Description
Fix artifact names (post Gradle to 8.5 update, https://github.com/opensearch-project/opensearch-hadoop/pull/377)

### Issues Resolved
Fixes GA failures (see please https://github.com/opensearch-project/opensearch-hadoop/actions/runs/7442871457/job/20246931394)

```
Run for i in `find . -path '*/distributions/*' -name "*.jar" -type f`; do sha1sum "$i" >> "$i.sha1"; done
sha1sum: ./build/poms/extension: No such file or directory
Error: Process completed with exit code 1.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
