### PR TITLE
Make invalid request exceptions more detailed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `io.netty:netty-all` from 4.1.107.Final to 4.1.108.Final
 
 ### Changed
+- Changes invalid request exception messages to always be detailed ([#438](https://github.com/opensearch-project/opensearch-hadoop/pull/438))
 
 ### Deprecated
 


### PR DESCRIPTION
### Description
Due to the logic [here](https://github.com/opensearch-project/opensearch-hadoop/blob/main/mr/src/main/java/org/opensearch/hadoop/rest/RestClient.java#L462-L465) in certain circumstances when a response indicates a client error (`4xx` status) but the response body is not an error object it may result in a non-sensical exception message like seen [here](https://github.com/opensearch-project/opensearch-hadoop/pull/350#issuecomment-2036866515):
```
org.opensearch.hadoop.rest.OpenSearchHadoopInvalidRequest: null
null
```

This change makes it so that the exception message always contains detailed information about the request being made and the response body, and if the response was an error it assigns it as the "cause" of the invalid request.

For example if you had your max scroll count setting too low the error would now look like:
```
Exception in thread "main" org.opensearch.hadoop.rest.OpenSearchHadoopInvalidRequest: [POST] on [test-index/_search] failed; server[127.0.0.1:9200] returned [429|Too Many Requests]
	at org.opensearch.hadoop.rest.RestClient.checkResponse(RestClient.java:489)
	at org.opensearch.hadoop.rest.RestClient.execute(RestClient.java:445)
	at org.opensearch.hadoop.rest.RestClient.execute(RestClient.java:439)
	at org.opensearch.hadoop.rest.RestClient.execute(RestClient.java:419)
	at org.opensearch.hadoop.rest.RestRepository.scroll(RestRepository.java:325)
	... <SNIP>
Caused by: org.opensearch.hadoop.rest.OpenSearchHadoopRemoteException: rejected_execution_exception: Trying to create too many scroll contexts. Must be less than or equal to: [0]. This limit can be set by changing the [search.max_open_scroll_context] setting.
	at org.opensearch.hadoop.rest.ErrorExtractor.extractErrorWithCause(ErrorExtractor.java:54)
	at org.opensearch.hadoop.rest.ErrorExtractor.extractError(ErrorExtractor.java:92)
	at org.opensearch.hadoop.rest.RestClient.checkResponse(RestClient.java:473)
	... 39 more
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
