### PR TITLE
Add basic HTTP compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Added basic support for HTTP compression when writing to OpenSearch ([#451](https://github.com/opensearch-project/opensearch-hadoop/pull/451))
 
 ### Changed
 

--- a/mr/src/main/java/org/opensearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/opensearch/hadoop/cfg/ConfigurationOptions.java
@@ -118,6 +118,10 @@ public interface ConfigurationOptions {
     String OPENSEARCH_HTTP_RETRIES = "opensearch.http.retries";
     String OPENSEARCH_HTTP_RETRIES_DEFAULT = "3";
 
+    /** HTTP compression */
+    String OPENSEARCH_HTTP_COMPRESSION = "opensearch.http.compression";
+    String OPENSEARCH_HTTP_COMPRESSION_DEFAULT = "false";
+
     /** Scroll keep-alive */
     String OPENSEARCH_SCROLL_KEEPALIVE = "opensearch.scroll.keepalive";
     String OPENSEARCH_SCROLL_KEEPALIVE_DEFAULT = "5m";

--- a/mr/src/main/java/org/opensearch/hadoop/cfg/Settings.java
+++ b/mr/src/main/java/org/opensearch/hadoop/cfg/Settings.java
@@ -176,6 +176,10 @@ public abstract class Settings {
         return Integer.valueOf(getProperty(OPENSEARCH_HTTP_RETRIES, OPENSEARCH_HTTP_RETRIES_DEFAULT));
     }
 
+    public boolean getHttpCompression() {
+        return Booleans.parseBoolean(getProperty(OPENSEARCH_HTTP_COMPRESSION, OPENSEARCH_HTTP_COMPRESSION_DEFAULT));
+    }
+
     public int getBatchSizeInBytes() {
         return ByteSizeValue.parseBytesSizeValue(getProperty(OPENSEARCH_BATCH_SIZE_BYTES, OPENSEARCH_BATCH_SIZE_BYTES_DEFAULT)).bytesAsInt();
     }

--- a/mr/src/main/java/org/opensearch/hadoop/mr/Counter.java
+++ b/mr/src/main/java/org/opensearch/hadoop/mr/Counter.java
@@ -44,6 +44,12 @@ public enum Counter {
             return stats.bytesSent;
         }
     },
+    COMPRESSED_BYTES_SENT {
+        @Override
+        public long get(Stats stats) {
+            return stats.compressedBytesSent;
+        }
+    },
     DOCS_SENT {
         @Override
         public long get(Stats stats) {

--- a/mr/src/main/java/org/opensearch/hadoop/rest/stats/Stats.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/stats/Stats.java
@@ -37,6 +37,7 @@ public class Stats {
 
     /** sent */
     public long bytesSent;
+    public long compressedBytesSent;
     public long docsSent;
     public long docsRetried;
     public long bytesRetried;
@@ -68,6 +69,7 @@ public class Stats {
         }
 
         this.bytesSent = stats.bytesSent;
+        this.compressedBytesSent = stats.compressedBytesSent;
         this.docsSent = stats.docsSent;
         this.bulkTotal = stats.bulkTotal;
 
@@ -98,6 +100,7 @@ public class Stats {
         }
 
         bytesSent += other.bytesSent;
+        compressedBytesSent += other.compressedBytesSent;
         docsSent += other.docsSent;
         bulkTotal += other.bulkTotal;
         docsRetried += other.docsRetried;

--- a/mr/src/main/resources/org/opensearch/hadoop/mr/Counter.properties
+++ b/mr/src/main/resources/org/opensearch/hadoop/mr/Counter.properties
@@ -3,6 +3,7 @@ BYTES_RECEIVED.name=Bytes Received
 BYTES_ACCEPTED.name=Bytes Accepted
 BYTES_RETRIED.name=Bytes Retried
 BYTES_SENT.name=Bytes Sent
+COMPRESSED_BYTES_SENT.name=Compressed Bytes Sent
 
 BULK_RETRIES.name=Bulk Retries
 BULK_RETRIES_TOTAL_TIME_MS.name=Bulk Retries Total Time(ms)

--- a/mr/src/test/java/org/opensearch/hadoop/rest/commonshttp/CommonsHttpTransportTests.java
+++ b/mr/src/test/java/org/opensearch/hadoop/rest/commonshttp/CommonsHttpTransportTests.java
@@ -29,10 +29,13 @@
 
 package org.opensearch.hadoop.rest.commonshttp;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
@@ -44,6 +47,8 @@ import org.opensearch.hadoop.thirdparty.apache.commons.httpclient.ConnectTimeout
 import org.opensearch.hadoop.thirdparty.apache.commons.httpclient.params.HttpConnectionParams;
 import org.opensearch.hadoop.thirdparty.apache.commons.httpclient.protocol.Protocol;
 import org.opensearch.hadoop.thirdparty.apache.commons.httpclient.protocol.ProtocolSocketFactory;
+import org.opensearch.hadoop.util.ByteSequence;
+import org.opensearch.hadoop.util.BytesArray;
 import org.opensearch.hadoop.util.TestSettings;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -143,5 +148,19 @@ public class CommonsHttpTransportTests {
             return;
         }
         fail("Should not be able to connect to TEST_NET_1");
+    }
+
+    @Test
+    public void testCompressByteSequence() throws Exception {
+        String data = "test";
+        ByteSequence ba = new BytesArray(data.getBytes(StandardCharsets.UTF_8));
+        ByteSequence compressed = CommonsHttpTransport.compressByteSequence(ba);
+
+        try(GZIPInputStream gzipInputStream = new GZIPInputStream(compressed.toInputStream())) {
+            byte[] decompressed = gzipInputStream.readAllBytes();
+            String result = new String(decompressed, StandardCharsets.UTF_8);
+
+            assertEquals(result, data);
+        }
     }
 }


### PR DESCRIPTION
### Description
Add basic support for HTTP compression when writing to OpenSearch.

This PR adapts https://github.com/s4ch1n/elasticsearch-hadoop/commit/d9327759a7f8da502e1b03789f5cab998b60c6e4 to add basic HTTP compression support without upgrading the [Apache HttpComponents](https://hc.apache.org/) dependency.

The [elasticsearch-hadoop](https://github.com/elastic/elasticsearch-hadoop) library and its [HTTP compression fork](https://github.com/s4ch1n/elasticsearch-hadoop/) use version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
