### PR TITLE
Fix Apache project dependency resolution for Hadoop, Hive, and Spark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fixed build failures when downloading Apache project dependencies (Hadoop, Hive, Spark)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
-- Fixed build failures when downloading Apache project dependencies (Hadoop, Hive, Spark)
+- Fixed build failures when downloading Apache project dependencies (Hadoop, Hive, Spark) ([#595](https://github.com/opensearch-project/opensearch-hadoop/pull/595))
 
 ### Security
 

--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/HadoopFixturePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/HadoopFixturePlugin.groovy
@@ -40,7 +40,7 @@ import org.gradle.api.artifacts.repositories.IvyPatternRepositoryLayout
 
 class HadoopFixturePlugin implements Plugin<Project> {
 
-    private static final String APACHE_MIRROR = "https://apache.osuosl.org/"
+    private static final String APACHE_MIRROR = "https://archive.apache.org/dist/"
 
     static class HadoopFixturePluginExtension {
         private NamedDomainObjectContainer<HadoopClusterConfiguration> clusters
@@ -81,10 +81,9 @@ class HadoopFixturePlugin implements Plugin<Project> {
         repositoryHandler.add(repositoryHandler.ivy({IvyArtifactRepository ivyArtifactRepository ->
             ivyArtifactRepository.setUrl(APACHE_MIRROR)
             ivyArtifactRepository.patternLayout({IvyPatternRepositoryLayout ivyPatternRepositoryLayout ->
-                // We use this pattern normally and break the regular tradition of a strictly numerical version
-                // because Hive does not provide a reasonable artifact name that makes a more robust pattern
-                // reasonable (it has a very unorthodox layout)
-                ivyPatternRepositoryLayout.artifact("[organization]/[module]/[revision].[ext]")
+                ivyPatternRepositoryLayout.artifact("[module]/common/[module]-[revision]/[module]-[revision].[ext]")
+                ivyPatternRepositoryLayout.artifact("[module]/[module]-[revision]/apache-[module]-[revision]-bin.[ext]")
+                ivyPatternRepositoryLayout.artifact("spark/spark-[revision]/spark-[revision]-bin-hadoop3.[ext]")
                 ivyPatternRepositoryLayout.setM2compatible(true)
             })
             ivyArtifactRepository.metadataSources({IvyArtifactRepository.MetadataSources metadataSources ->

--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/services/HadoopServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/services/HadoopServiceDescriptor.groovy
@@ -77,7 +77,8 @@ class HadoopServiceDescriptor implements ServiceDescriptor {
 
     @Override
     String getDependencyCoordinates(ServiceConfiguration configuration) {
-        return "hadoop.common:hadoop-${configuration.getVersion()}:${artifactName(configuration)}@tar.gz"
+        Version version = configuration.getVersion()
+        return "apache:hadoop:${configuration.getVersion()}@tar.gz"
     }
 
     @Override

--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/services/HiveServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/services/HiveServiceDescriptor.groovy
@@ -74,7 +74,7 @@ class HiveServiceDescriptor implements ServiceDescriptor {
 
     @Override
     String getDependencyCoordinates(ServiceConfiguration configuration) {
-        return "hive:hive-${configuration.getVersion()}:${artifactName(configuration)}@tar.gz"
+        return "apache:hive:${configuration.getVersion()}@tar.gz"
     }
 
     @Override

--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/services/SparkYarnServiceDescriptor.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/fixture/hadoop/services/SparkYarnServiceDescriptor.groovy
@@ -77,7 +77,7 @@ class SparkYarnServiceDescriptor implements ServiceDescriptor {
 
     @Override
     String getDependencyCoordinates(ServiceConfiguration configuration) {
-        return "spark:spark-${configuration.getVersion()}:${artifactName(configuration)}@tgz"
+        return "apache:spark:${configuration.getVersion()}@tgz"
     }
 
     @Override


### PR DESCRIPTION
### Description
This PR fixes build failures when downloading Apache project dependencies (Hadoop, Hive, Spark) by addressing several issues:

1. Updated Apache mirror URL from `apache.osuosl.org` (which has DNS resolution issues) to the official Apache archive
2. Fixed Ivy artifact patterns to match actual Apache distribution directory structures
3. Standardized dependency coordinates across all Apache projects

When building the project from a fresh clone, Gradle fails to resolve Hadoop, Hive, and Spark dependencies due to:
- DNS resolution failures for `apache.osuosl.org`
- Incorrect artifact patterns that don't match Apache's actual directory structure
- Inconsistent dependency coordinate formats

Related to elastic/elasticsearch-hadoop#2197

To address them,
- Changed Apache mirror to use `https://archive.apache.org/dist/` which is more reliable
- Added specific artifact patterns for each Apache project:
  - Hadoop: `[module]/common/[module]-[revision]/[module]-[revision].[ext]`
  - Hive: `[module]/[module]-[revision]/apache-[module]-[revision]-bin.[ext]`
  - Spark: `spark/spark-[revision]/spark-[revision]-bin-hadoop3.[ext]`
- Unified dependency coordinates to use `apache:[module]:[version]@[ext]` format

### Issues Resolved
Fix #596 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
