### PR TITLE
Switched to more reliable OpenSearch Lucene snapshot location

### DIFF
--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -200,7 +200,7 @@ class BaseBuildPlugin implements Plugin<Project> {
             String revision = (project.ext.luceneVersion =~ /\w+-snapshot-([a-z0-9]+)/)[0][1]
             project.repositories.maven {
                 name = 'lucene-snapshots'
-                url = "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/${revision}"
+                url = "https://artifacts.opensearch.org/snapshots/lucene/${revision}"
             }
         }
     }


### PR DESCRIPTION
### Description
Switched to more reliable OpenSearch Lucene snapshot location

Related
https://github.com/opensearch-project/opensearch-build/issues/3874

### Issues Resolved
Fix #385 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
