### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -114,19 +114,19 @@ jobs:
           repository: 'opensearch-project/opensearch-build-libraries'
           path: 'build'
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
 
       - name: Get credentials and publish snapshots to maven
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
-          export SNAPSHOT_REPO_URL="https://aws.oss.sonatype.org/content/repositories/snapshots/"
+          export SNAPSHOT_REPO_URL="https://central.sonatype.com/repository/maven-snapshots/"
           build/resources/publish/publish-snapshot.sh $MAVEN_HOME
 
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,4 +41,4 @@ The release process is standard across repositories in this org and is run by a 
 1. Increment the version in [opensearch-hadoop-version.properties](./buildSrc/opensearch-hadoop-version.properties) to the next patch release, e.g. `2.1.1`.
 
 ## Snapshot Builds
-The [snapshots builds](https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/client/) are published to sonatype using [publish_snapshot.yml](./.github/workflows/publish_snapshot.yml) workflow. Each `push` event to the main branch triggers this workflow.
+The [snapshots builds](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/client/) are published to sonatype using [publish_snapshot.yml](./.github/workflows/publish_snapshot.yml) workflow. Each `push` event to the main branch triggers this workflow.

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -60,6 +60,7 @@ repositories {
         // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.
         flatDir { dirs new File(project.rootDir, "../localRepo") }
     } else if (snapshot) {
+        maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     }
     else {

--- a/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/BaseBuildPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/opensearch/hadoop/gradle/BaseBuildPlugin.groovy
@@ -178,6 +178,7 @@ class BaseBuildPlugin implements Plugin<Project> {
 
         // For OpenSearch snapshots.
         project.repositories.maven { url = "https://artifacts.opensearch.org/snapshots/" } // default
+        project.repositories.maven { url = "https://central.sonatype.com/repository/maven-snapshots/" } // central portal snapshot
         project.repositories.maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" } // oss-only
 
         // OpenSearch artifacts

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -49,6 +49,7 @@ subprojects {
                 // For some reason the root dirs all point to the buildSrc folder. The local Repo will be one above that.
                 flatDir { dirs new File(project.rootProject.rootDir, "localRepo") }
             } else {
+                maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
                 maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
             }
         }

--- a/repository-hdfs/README.md
+++ b/repository-hdfs/README.md
@@ -83,7 +83,7 @@ Or grab the latest nightly build from the [repository](http://oss.sonatype.org/c
 <repositories>
   <repository>
     <id>sonatype-oss</id>
-    <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots</url>
     <snapshots><enabled>true</enabled></snapshots>
   </repository>
 </repositories>


### PR DESCRIPTION
### Description
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration. 
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the `onepassword` token in this repo secrets and new credentials for Sonatypes username & password have been stored in `onepassword`.  These credentials will be exported as env variables which used by maven publish.

### Issues Resolved
Part of a campaign from https://github.com/opensearch-project/opensearch-build/issues/5551

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
