### PR TITLE
Improve documentation with quick start guide, usage examples, and updated compatibility

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,28 +1,38 @@
+- [Compatibility with Java](#compatibility-with-java)
 - [Compatibility with OpenSearch](#compatibility-with-opensearch)
 - [Compatibility with Spark and Scala](#compatibility-with-spark-and-scala)
 - [Compatibility with AWS Glue](#compatibility-with-aws-glue)
+
+## Compatibility with Java
+
+| Client Version | Minimum Runtime | Build Requirement |
+|----------------|-----------------|-------------------|
+| 1.0.0-1.3.0   | Java 8          | JDK 14            |
+| 2.0.0          | Java 11         | JDK 21            |
 
 ## Compatibility with OpenSearch
 
 The below matrix shows the compatibility of the [`opensearch-hadoop`](https://central.sonatype.com/artifact/org.opensearch.client/opensearch-hadoop) with versions of [`OpenSearch`](https://opensearch.org/downloads.html#opensearch).
 
-| Client Version | OpenSearch Version | ElasticSearch Version |
-|----------------|--------------------| --------------------- |
-| 1.0.0-1.1.0    | 1.0.0-2.12.0       | 7.x                   |
+| Client Version | OpenSearch Version |
+|----------------|--------------------|
+| 1.0.0-1.3.0   | 1.x, 2.x          |
+| 2.0.0          | 1.x, 2.x, 3.x     |
 
 ## Compatibility with Spark and Scala
 
-| Client Version | Spark Version | Scala Version(s) |
-|----------------| ------------- | ---------------- |
-| 1.0.0-1.3.0    | 3.4.4         | 2.12/2.13        |
-| unreleased     | 3.5.x         | 2.12/2.13        |
-| unreleased     | 4.1.1         | 2.13             |
+| Client Version | Module | Spark Version | Scala Version(s) |
+|----------------|--------|---------------|-------------------|
+| 1.0.0-1.3.0   | opensearch-spark-30 | 3.4.x | 2.12, 2.13 |
+| 2.0.0          | opensearch-spark-30 | 3.4.x | 2.12, 2.13 |
+| 2.0.0          | opensearch-spark-35 | 3.5.x | 2.12, 2.13 |
+| 2.0.0          | opensearch-spark-40 | 4.x   | 2.13       |
 
-Note: Client versions 1.0.0-1.3.0 can be used with Spark 3.5.x for batch reads and writes (Spark SQL, RDD). Structured Streaming writes require the upcoming release with the dedicated `opensearch-spark-35` module.
+Note: Client versions 1.0.0-1.3.0 can be used with Spark 3.5.x for batch reads and writes (Spark SQL, RDD). Structured Streaming writes require version 2.0.0 with the dedicated `opensearch-spark-35` module.
 
 ## Compatibility with AWS Glue
 
 | Client Version | Spark Version | Glue Version(s) |
-|----------------| ------------- | --------------- |
-| 1.0.0-1.3.0    | 3.4.4         | 3/4             |
-| unreleased     | 3.5.x         | 5.0/5.1         |
+|----------------|---------------|-----------------|
+| 1.0.0-1.3.0   | 3.4.x         | 3, 4            |
+| 2.0.0          | 3.5.x         | 5.0, 5.1        |

--- a/README.md
+++ b/README.md
@@ -9,65 +9,82 @@
 ![OpenSearch logo](OpenSearch.svg)
 
 # OpenSearch Hadoop
-OpenSearch real-time search and analytics natively integrated with Hadoop.
-Supports [Map/Reduce](#mapreduce), [Apache Hive](#apache-hive), [Apache Spark](#apache-spark).
 
-- [OpenSearch Hadoop](#opensearch-hadoop)
-  - [Requirements](#requirements)
-  - [Usage](#usage)
-  - [Compatibility](#compatibility)
-  - [Building the source](#building-the-source)
-  - [License](#license)
+A connector for reading and writing data between [Apache Spark](http://spark.apache.org) and [OpenSearch](https://opensearch.org/). It enables Spark jobs to directly index data into OpenSearch and run queries against it, with parallel reads and writes across Spark partitions and OpenSearch shards for efficient distributed processing.
+
+Also supports [Apache Hive](http://hive.apache.org) and Hadoop [Map/Reduce](http://hadoop.apache.org/docs/r1.2.1/mapred_tutorial.html). Works with any OpenSearch cluster accessible via REST, including Amazon OpenSearch Service and Amazon OpenSearch Serverless.
+
+**Use cases:**
+- Index large datasets from Spark ETL pipelines into OpenSearch
+- Query OpenSearch from Spark for analytics, reporting, and machine learning
+- Build search-powered applications backed by Spark data pipelines
+- Bridge your data lake or lakehouse with search and analytics on OpenSearch
+
+## Quick Start
+
+Write a Spark DataFrame to OpenSearch and read it back, using PySpark:
+
+```bash
+pyspark --packages org.opensearch.client:opensearch-spark-30_2.12:2.0.0 \
+        --conf spark.opensearch.nodes=localhost \
+        --conf spark.opensearch.nodes.wan.only=true
+```
+
+```python
+# Write
+df = spark.createDataFrame([("hello", 1), ("world", 2)], ["name", "value"])
+df.write.format("opensearch").save("my-index")
+
+# Read
+result = spark.read.format("opensearch").load("my-index")
+result.show()
+```
+
+For Scala, Java, Spark SQL, RDD, and more examples, see the [User Guide](USER_GUIDE.md).
+For Amazon OpenSearch Service and OpenSearch Serverless, see the [User Guide](USER_GUIDE.md#amazon-opensearch-service).
+
+## Maven Coordinates
+
+Choose the artifact that matches your Spark and Scala version:
+
+| Spark Version | Scala Version | Artifact |
+|---------------|---------------|----------|
+| 3.4.x | 2.12 | `org.opensearch.client:opensearch-spark-30_2.12:2.0.0` |
+| 3.4.x | 2.13 | `org.opensearch.client:opensearch-spark-30_2.13:2.0.0` |
+| 3.5.x | 2.12 | `org.opensearch.client:opensearch-spark-35_2.12:2.0.0` |
+| 3.5.x | 2.13 | `org.opensearch.client:opensearch-spark-35_2.13:2.0.0` |
+| 4.x | 2.13 | `org.opensearch.client:opensearch-spark-40_2.13:2.0.0` |
+
+For Map/Reduce and Hive, see `org.opensearch.client:opensearch-hadoop-mr` and `org.opensearch.client:opensearch-hadoop-hive` on [Maven Central](https://central.sonatype.com/search?q=org.opensearch.client%20opensearch-hadoop).
 
 ## Requirements
-OpenSearch (__1.3.x__ or higher) cluster accessible through REST. That's it!
-If using SigV4 IAM auth features, you would need to include the following AWS SDK v2 dependencies in your job classpath:
-- `software.amazon.awssdk:auth:2.31.59` (or later)
-- `software.amazon.awssdk:regions:2.31.59` (or later)
-- `software.amazon.awssdk:http-client-spi:2.31.59` (or later)
-- `software.amazon.awssdk:identity-spi:2.31.59` (or later)
-- `software.amazon.awssdk:sdk-core:2.31.59` (or later)
-- `software.amazon.awssdk:utils:2.31.59` (or later)
 
-## Usage
-
-Please see the [USER_GUIDE](USER_GUIDE.md) for usage.
+- OpenSearch 1.x or later (including Amazon OpenSearch Service and Serverless)
+- Java 11 or later at runtime
+- Java 21 to build from source
+- For SigV4 IAM authentication, additional AWS SDK dependencies are required. See the [User Guide](USER_GUIDE.md).
 
 ## Compatibility
 
-See [Compatibility](COMPATIBILITY.md).
+See [COMPATIBILITY.md](COMPATIBILITY.md).
 
-## Building the source
+## Building from Source
 
-OpenSearch Hadoop uses [Gradle][] for its build system and it is not required to have it installed on your machine. By default (`gradlew`), it automatically builds the package and runs the unit tests. For integration testing, use the `integrationTests` task.
-See `gradlew tasks` for more information.
+OpenSearch Hadoop uses [Gradle](http://www.gradle.org/) for its build system. JDK 21 is required.
 
-To create a distributable zip, run `gradlew distZip` from the command line; once completed you will find the jar in `build/libs`.
+```bash
+./gradlew build           # build and run unit tests
+./gradlew integrationTests # run integration tests
+./gradlew distZip          # create distributable zip
+```
 
-To build the project, JVM 21 is required. The minimum compiler version is Java 21 and the minimum runtime is Java 11.
+## Documentation
+
+- [User Guide](USER_GUIDE.md) — usage examples for Spark, Hive, and Map/Reduce
+- [Compatibility](COMPATIBILITY.md) — supported versions of OpenSearch, Spark, and Scala
+- [Contributing](CONTRIBUTING.md)
+- [Changelog](CHANGELOG.md)
 
 ## License
-This project is released under version 2.0 of the [Apache License][]
 
-```
-Licensed to Elasticsearch under one or more contributor
-license agreements. See the NOTICE file distributed with
-this work for additional information regarding copyright
-ownership. Elasticsearch licenses this file to you under
-the Apache License, Version 2.0 (the "License"); you may
-not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-```
-
-[Hadoop]: http://hadoop.apache.org
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
-[Gradle]: http://www.gradle.org/
+This project is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,337 +1,473 @@
+# User Guide
+
+- [Spark](#spark)
+  - [Setup](#setup)
+  - [PySpark](#pyspark)
+  - [Scala](#scala)
+  - [Java](#java)
+  - [Spark SQL](#spark-sql)
+  - [Spark RDD](#spark-rdd)
+  - [Structured Streaming](#structured-streaming)
+  - [Common Patterns](#common-patterns)
 - [Configuration Properties](#configuration-properties)
   - [Required](#required)
   - [Essential](#essential)
+- [Amazon OpenSearch Service](#amazon-opensearch-service)
+- [Amazon OpenSearch Serverless](#amazon-opensearch-serverless)
 - [Map/Reduce](#mapreduce)
-  - ['Old' (`org.apache.hadoop.mapred`) API](#old-orgapachehadoopmapred-api)
-  - [Reading](#reading)
-  - [Writing](#writing)
-  - ['New' (`org.apache.hadoop.mapreduce`) API](#new-orgapachehadoopmapreduce-api)
-  - [Reading](#reading-1)
-  - [Writing](#writing-1)
-  - [Signing requests for IAM authentication](#signing-requests-for-iam-authentication)
+  - [Old API (`org.apache.hadoop.mapred`)](#old-api-orgapachehadoopmapred)
+  - [New API (`org.apache.hadoop.mapreduce`)](#new-api-orgapachehadoopmapreduce)
 - [Apache Hive](#apache-hive)
-  - [Reading](#reading-2)
-  - [Writing](#writing-2)
-  - [Signing requests for IAM authentication](#signing-requests-for-iam-authentication-1)
-- [Apache Spark](#apache-spark)
-  - [Scala](#scala)
-  - [Reading](#reading-3)
-    - [Spark SQL](#spark-sql)
-  - [Writing](#writing-3)
-    - [Spark SQL](#spark-sql-1)
-  - [Java](#java)
-  - [Reading](#reading-4)
-    - [Spark SQL](#spark-sql-2)
-  - [Writing](#writing-4)
-    - [Spark SQL](#spark-sql-3)
-  - [Signing requests for IAM authentication](#signing-requests-for-iam-authentication-2)
 
+## Spark
+
+### Setup
+
+Add the opensearch-hadoop connector to your Spark application using `--packages`:
+
+```bash
+# Spark 3.4.x
+pyspark --packages org.opensearch.client:opensearch-spark-30_2.12:2.0.0
+
+# Spark 3.5.x
+pyspark --packages org.opensearch.client:opensearch-spark-35_2.12:2.0.0
+
+# Spark 4.x
+pyspark --packages org.opensearch.client:opensearch-spark-40_2.13:2.0.0
+```
+
+Or add it as a dependency in your build file:
+
+```xml
+<!-- Maven (Spark 3.4.x, Scala 2.12) -->
+<dependency>
+    <groupId>org.opensearch.client</groupId>
+    <artifactId>opensearch-spark-30_2.12</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+```groovy
+// Gradle (Spark 3.4.x, Scala 2.12)
+implementation 'org.opensearch.client:opensearch-spark-30_2.12:2.0.0'
+```
+
+See the [README](README.md#maven-coordinates) for the full list of artifacts for each Spark and Scala version.
+
+### PySpark
+
+No additional Python package is needed. The Java connector is loaded via `--packages` or `spark.jars`.
+
+```python
+# Write (index documents into OpenSearch)
+df = spark.createDataFrame([("John", 30), ("Jane", 25)], ["name", "age"])
+df.write.format("opensearch").save("people")
+
+# Read (query documents from OpenSearch)
+df = spark.read.format("opensearch").load("people")
+df.show()
+
+# Read with a query (only matching documents are transferred to Spark)
+filtered = spark.read \
+    .format("opensearch") \
+    .option("opensearch.query", '{"query":{"match":{"name":"John"}}}') \
+    .load("people")
+```
+
+### Scala
+
+```scala
+import org.opensearch.spark.sql._
+
+// Write (index documents into OpenSearch)
+val df = spark.createDataFrame(Seq(("John", 30), ("Jane", 25))).toDF("name", "age")
+df.saveToOpenSearch("people")
+
+// With options
+df.saveToOpenSearch("people", Map(
+  "opensearch.nodes" -> "my-cluster",
+  "opensearch.port" -> "9200"
+))
+
+// Read (query documents from OpenSearch)
+val result = spark.read.format("opensearch").load("people")
+result.show()
+
+// Read with a query
+val filtered = spark.read
+  .format("opensearch")
+  .option("opensearch.query", """{"query":{"match":{"name":"John"}}}""")
+  .load("people")
+```
+
+### Java
+
+```java
+import org.opensearch.spark.sql.api.java.JavaOpenSearchSparkSQL;
+
+// Write
+Dataset<Row> df = spark.createDataFrame(data, schema);
+JavaOpenSearchSparkSQL.saveToOpenSearch(df, "people");
+
+// Read
+Dataset<Row> result = spark.read().format("opensearch").load("people");
+result.show();
+```
+
+### Spark SQL
+
+You can register an OpenSearch index as a temporary view and query it with SQL:
+
+```python
+spark.sql("""
+  CREATE TEMPORARY VIEW people
+  USING opensearch
+  OPTIONS (resource 'people')
+""")
+
+spark.sql("SELECT * FROM people WHERE age > 25").show()
+```
+
+### Spark RDD
+
+For low-level access, opensearch-hadoop provides RDD-based read and write methods.
+
+#### Scala
+
+```scala
+import org.opensearch.spark._
+
+// Write
+val data = sc.makeRDD(Seq(
+  Map("name" -> "John", "age" -> 30),
+  Map("name" -> "Jane", "age" -> 25)
+))
+data.saveToOpenSearch("people")
+
+// Read
+val rdd = sc.opensearchRDD("people")
+rdd.collect().foreach(println)
+
+// Read with query
+val filtered = sc.opensearchRDD("people", "?q=name:John")
+```
+
+#### Java
+
+```java
+import org.opensearch.spark.rdd.api.java.JavaOpenSearchSpark;
+
+// Write
+JavaRDD<Map<String, ?>> javaRDD = jsc.parallelize(data);
+JavaOpenSearchSpark.saveToOpenSearch(javaRDD, "people");
+
+// Read
+JavaPairRDD<String, Map<String, Object>> rdd = JavaOpenSearchSpark.opensearchRDD(jsc, "people");
+```
+
+### Structured Streaming
+
+opensearch-hadoop supports Spark Structured Streaming as a sink:
+
+```scala
+val query = streamingDF.writeStream
+  .format("opensearch")
+  .option("checkpointLocation", "/tmp/checkpoint")
+  .start("streaming-index")
+```
+
+### Common Patterns
+
+#### Specifying Document ID
+
+Use `opensearch.mapping.id` to control the `_id` of each document. This is useful for upserts and deduplication:
+
+```python
+df.write.format("opensearch") \
+    .option("opensearch.mapping.id", "id") \
+    .save("my-index")
+```
+
+#### Write Modes
+
+Spark's `SaveMode` controls how data is written:
+
+```python
+# Append (default): add documents to the index
+df.write.format("opensearch").mode("append").save("my-index")
+
+# Overwrite: delete the index and recreate it with the new data
+df.write.format("opensearch").mode("overwrite").save("my-index")
+```
+
+#### Upsert
+
+Update existing documents or insert new ones using `opensearch.write.operation`:
+
+```python
+df.write.format("opensearch") \
+    .option("opensearch.mapping.id", "id") \
+    .option("opensearch.write.operation", "upsert") \
+    .save("my-index")
+```
+
+Other write operations: `index` (default), `create`, `update`.
+
+#### Reading with a Query
+
+Filter data at the OpenSearch level using `opensearch.query`, so only matching documents are loaded into Spark:
+
+```python
+# Query DSL
+df = spark.read.format("opensearch") \
+    .option("opensearch.query", '{"query":{"range":{"age":{"gte":25}}}}') \
+    .load("my-index")
+
+# URI query
+df = spark.read.format("opensearch") \
+    .option("opensearch.query", "?q=name:John") \
+    .load("my-index")
+```
+
+#### Selecting Fields
+
+Load only specific fields from OpenSearch to reduce data transfer:
+
+```python
+df = spark.read.format("opensearch") \
+    .option("opensearch.read.field.include", "name,age") \
+    .load("my-index")
+```
+
+#### Scroll Size
+
+Control how many documents are fetched per batch when reading:
+
+```python
+df = spark.read.format("opensearch") \
+    .option("opensearch.scroll.size", "5000") \
+    .load("my-index")
+```
+
+#### Basic Authentication
+
+```python
+df.write.format("opensearch") \
+    .option("opensearch.net.http.auth.user", "<username>") \
+    .option("opensearch.net.http.auth.pass", "<password>") \
+    .save("my-index")
+```
+
+#### HTTPS
+
+```python
+df.write.format("opensearch") \
+    .option("opensearch.net.ssl", "true") \
+    .save("my-index")
+```
+
+#### Separate Read and Write Indices
+
+Use different indices for reading and writing:
+
+```python
+# Write to a specific index
+df.write.format("opensearch") \
+    .option("opensearch.resource.write", "logs-2026.03") \
+    .save("logs-2026.03")
+
+# Read from an alias or different index
+df = spark.read.format("opensearch") \
+    .option("opensearch.resource.read", "logs-alias") \
+    .load("logs-alias")
+```
+
+#### Dynamic Index Routing
+
+Use placeholders in the index name to route documents to different indices based on field values. This feature requires the Scala `saveToOpenSearch` method:
+
+```scala
+import org.opensearch.spark.sql._
+
+// Route by field value: {"category": "electronics", "name": "TV"} -> index "electronics"
+df.saveToOpenSearch("{category}")
+
+// Prefix + field value: {"env": "prod", "msg": "ok"} -> index "logs-prod"
+df.saveToOpenSearch("logs-{env}")
+
+// Date formatting: {"timestamp": "2026-02-16T10:30:00.000Z", "msg": "ok"} -> index "logs-2026.02.16"
+df.saveToOpenSearch("logs-{timestamp|yyyy.MM.dd}")
+```
 
 ## Configuration Properties
 
-All configuration properties start with `opensearch` prefix. Note that the `opensearch.internal` namespace is reserved for the library internal use and should _not_ be used by the user at any point.
-The properties are read mainly from the Hadoop configuration but the user can specify (some of) them directly depending on the library used.
+All configuration properties start with the `opensearch` prefix. The `opensearch.internal` namespace is reserved for internal use.
+
+Properties can be set via Spark configuration (`--conf`), as options on the DataFrame reader/writer, or in the Hadoop configuration.
 
 ### Required
 
-```
-opensearch.resource=<OpenSearch resource location, relative to the host/port specified above>
-```
+| Property | Description |
+|----------|-------------|
+| `opensearch.resource` | OpenSearch index name (e.g., `my-index`). Can also be specified as the argument to `saveToOpenSearch()` or `load()`. |
 
 ### Essential
 
+| Property | Default | Description |
+|----------|---------|-------------|
+| `opensearch.nodes` | `localhost` | OpenSearch host address |
+| `opensearch.port` | `9200` | OpenSearch REST port |
+| `opensearch.nodes.wan.only` | `false` | Set to `true` when connecting through a load balancer or proxy (e.g., Docker, Kubernetes, cloud environments) |
+| `opensearch.query` | match all | Query DSL or URI query for reading (e.g., `{"query":{"match":{"name":"John"}}}`) |
+| `opensearch.net.ssl` | `false` | Enable HTTPS |
+| `opensearch.mapping.id` | (none) | Document field to use as the `_id` |
+| `opensearch.write.operation` | `index` | Write operation: `index`, `create`, `update`, `upsert` |
+
+## Amazon OpenSearch Service
+
+To connect to Amazon OpenSearch Service with IAM authentication, enable SigV4 signing and HTTPS:
+
+```python
+df.write.format("opensearch") \
+    .option("opensearch.nodes", "https://search-xxx.us-east-1.es.amazonaws.com") \
+    .option("opensearch.port", "443") \
+    .option("opensearch.net.ssl", "true") \
+    .option("opensearch.nodes.wan.only", "true") \
+    .option("opensearch.aws.sigv4.enabled", "true") \
+    .option("opensearch.aws.sigv4.region", "us-east-1") \
+    .save("my-index")
 ```
-opensearch.query=<uri or query dsl query>      # defaults to {"query":{"match_all":{}}}
-opensearch.nodes=<OpenSearch host address>     # defaults to localhost
-opensearch.port=<OPENSEARCH REST port>         # defaults to 9200
+
+Reading works the same way:
+
+```python
+df = spark.read.format("opensearch") \
+    .option("opensearch.nodes", "https://search-xxx.us-east-1.es.amazonaws.com") \
+    .option("opensearch.port", "443") \
+    .option("opensearch.net.ssl", "true") \
+    .option("opensearch.nodes.wan.only", "true") \
+    .option("opensearch.aws.sigv4.enabled", "true") \
+    .option("opensearch.aws.sigv4.region", "us-east-1") \
+    .load("my-index")
 ```
 
-## [Map/Reduce][]
+The following AWS SDK v2 dependencies are required on the classpath:
+- `software.amazon.awssdk:auth:2.31.59` (or later)
+- `software.amazon.awssdk:regions:2.31.59` (or later)
+- `software.amazon.awssdk:http-client-spi:2.31.59` (or later)
+- `software.amazon.awssdk:identity-spi:2.31.59` (or later)
+- `software.amazon.awssdk:sdk-core:2.31.59` (or later)
+- `software.amazon.awssdk:utils:2.31.59` (or later)
 
-For basic, low-level or performance-sensitive environments, OpenSearch-Hadoop provides dedicated `InputFormat` and `OutputFormat` that read and write data to OpenSearch. To use them, add the `opensearch-hadoop` jar to your job classpath
-(either by bundling the library along - it's ~300kB and there are no-dependencies), using the [DistributedCache][] or by provisioning the cluster manually.
+## Amazon OpenSearch Serverless
 
-Note that os-hadoop supports both the so-called 'old' and the 'new' API through its `OpenSearchInputFormat` and `OpenSearchOutputFormat` classes.
+To connect to Amazon OpenSearch Serverless, add `opensearch.serverless` and set the SigV4 service name to `aoss`:
 
-### 'Old' (`org.apache.hadoop.mapred`) API
+```python
+df.write.format("opensearch") \
+    .option("opensearch.nodes", "https://xxx.us-east-1.aoss.amazonaws.com") \
+    .option("opensearch.port", "443") \
+    .option("opensearch.net.ssl", "true") \
+    .option("opensearch.nodes.wan.only", "true") \
+    .option("opensearch.aws.sigv4.enabled", "true") \
+    .option("opensearch.aws.sigv4.region", "us-east-1") \
+    .option("opensearch.aws.sigv4.service.name", "aoss") \
+    .option("opensearch.serverless", "true") \
+    .save("my-index")
+```
 
-### Reading
+You can configure the page size for reads with `opensearch.search_after.size` (default: 1000):
 
-To read data from OpenSearch, configure the `OpenSearchInputFormat` on your job configuration along with the relevant [properties](#configuration-properties):
+```python
+df = spark.read.format("opensearch") \
+    .option("opensearch.nodes", "https://xxx.us-east-1.aoss.amazonaws.com") \
+    .option("opensearch.port", "443") \
+    .option("opensearch.net.ssl", "true") \
+    .option("opensearch.nodes.wan.only", "true") \
+    .option("opensearch.aws.sigv4.enabled", "true") \
+    .option("opensearch.aws.sigv4.region", "us-east-1") \
+    .option("opensearch.aws.sigv4.service.name", "aoss") \
+    .option("opensearch.serverless", "true") \
+    .option("opensearch.search_after.size", "1000") \
+    .load("my-index")
+```
+
+## Map/Reduce
+
+For low-level Hadoop Map/Reduce jobs, opensearch-hadoop provides `OpenSearchInputFormat` and `OpenSearchOutputFormat`. Add `opensearch-hadoop-mr-2.0.0.jar` to your job classpath.
+
+### Old API (`org.apache.hadoop.mapred`)
 
 ```java
+// Reading
 JobConf conf = new JobConf();
 conf.setInputFormat(OpenSearchInputFormat.class);
-conf.set("opensearch.resource", "radio/artists");
-conf.set("opensearch.query", "?q=me*");             // replace this with the relevant query
-...
+conf.set("opensearch.resource", "my-index");
+conf.set("opensearch.query", "?q=name:John");
 JobClient.runJob(conf);
-```
 
-### Writing
-
-Same configuration template can be used for writing but using `OpenSearchOuputFormat`:
-
-```java
+// Writing
 JobConf conf = new JobConf();
 conf.setOutputFormat(OpenSearchOutputFormat.class);
-conf.set("opensearch.resource", "radio/artists"); // index or indices used for storing data
-...
+conf.set("opensearch.resource", "my-index");
 JobClient.runJob(conf);
 ```
 
-### 'New' (`org.apache.hadoop.mapreduce`) API
-
-### Reading
+### New API (`org.apache.hadoop.mapreduce`)
 
 ```java
+// Reading
 Configuration conf = new Configuration();
-conf.set("opensearch.resource", "radio/artists");
-conf.set("opensearch.query", "?q=me*");             // replace this with the relevant query
-Job job = new Job(conf)
+conf.set("opensearch.resource", "my-index");
+conf.set("opensearch.query", "?q=name:John");
+Job job = new Job(conf);
 job.setInputFormatClass(OpenSearchInputFormat.class);
-...
 job.waitForCompletion(true);
-```
 
-### Writing
-
-```java
+// Writing
 Configuration conf = new Configuration();
-conf.set("opensearch.resource", "radio/artists"); // index or indices used for storing data
-Job job = new Job(conf)
+conf.set("opensearch.resource", "my-index");
+Job job = new Job(conf);
 job.setOutputFormatClass(OpenSearchOutputFormat.class);
-...
 job.waitForCompletion(true);
 ```
 
-### Signing requests for IAM authentication
+## Apache Hive
 
-Signing requests would require the [aws-sdk-bundle](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bundle) in your job classpath.
+opensearch-hadoop provides a Hive storage handler. Add `opensearch-hadoop-hive-2.0.0.jar` to your Hive classpath:
 
-```java
-Configuration conf = new Configuration();
-conf.set("opensearch.resource", "radio/artists");
-conf.set("opensearch.query", "?q=me*");             // replace this with the relevant query
-conf.set("opensearch.nodes", "https://search-xxx.us-east-1.es.amazonaws.com");
-conf.set("opensearch.port", "443");
-conf.set("opensearch.net.ssl", "true");
-conf.set("opensearch.nodes.wan.only", "true");
-conf.set("opensearch.aws.sigv4.enabled", "true");
-conf.set("opensearch.aws.sigv4.region", "us-east-1");
-Job job = new Job(conf)
-job.setInputFormatClass(OpenSearchInputFormat.class);
-...
-job.waitForCompletion(true);
+```sql
+ADD JAR /path/opensearch-hadoop-hive-2.0.0.jar;
 ```
 
-## [Apache Hive][]
-
-OpenSearch-Hadoop provides a Hive storage handler for OpenSearch, meaning one can define an [external table][] on top of OpenSearch.
-
-Add opensearch-hadoop-<version>.jar to `hive.aux.jars.path` or register it manually in your Hive script (recommended):
-
-```
-ADD JAR /path_to_jar/opensearch-hadoop-<version>.jar;
-```
-
-### Reading
-
-To read data from OpenSearch, define a table backed by the desired index:
-
-```SQL
-CREATE EXTERNAL TABLE artists (
-    id      BIGINT,
-    name    STRING,
-    links   STRUCT<url:STRING, picture:STRING>)
+```sql
+-- Create an external table backed by an OpenSearch index
+CREATE EXTERNAL TABLE people (
+    name STRING,
+    age  INT)
 STORED BY 'org.opensearch.hadoop.hive.OpenSearchStorageHandler'
-TBLPROPERTIES('opensearch.resource' = 'radio/artists', 'opensearch.query' = '?q=me*');
+TBLPROPERTIES('opensearch.resource' = 'people');
+
+-- Read
+SELECT * FROM people;
+
+-- Write from another table
+INSERT OVERWRITE TABLE people SELECT name, age FROM source;
 ```
 
-The fields defined in the table are mapped to the JSON when communicating with OpenSearch. Notice the use of `TBLPROPERTIES` to define the location, that is the query used for reading from this table.
+For IAM authentication with Hive, add the SigV4 properties to `TBLPROPERTIES`:
 
-Once defined, the table can be used just like any other:
-
-```SQL
-SELECT * FROM artists;
-```
-
-### Writing
-
-To write data, a similar definition is used but with a different `opensearch.resource`:
-
-```SQL
-CREATE EXTERNAL TABLE artists (
-    id      BIGINT,
-    name    STRING,
-    links   STRUCT<url:STRING, picture:STRING>)
-STORED BY 'org.opensearch.hadoop.hive.OpenSearchStorageHandler'
-TBLPROPERTIES('opensearch.resource' = 'radio/artists');
-```
-
-Any data passed to the table is then passed down to OpenSearch; for example considering a table `s`, mapped to a TSV/CSV file, one can index it to OpenSearch like this:
-
-```SQL
-INSERT OVERWRITE TABLE artists
-    SELECT NULL, s.name, named_struct('url', s.url, 'picture', s.picture) FROM source s;
-```
-
-As one can note, currently the reading and writing are treated separately but we're working on unifying the two and automatically translating [HiveQL][] to OpenSearch queries.
-
-### Signing requests for IAM authentication
-
-Signing requests would require the [aws-sdk-bundle](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bundle) in your job classpath.
-
-```SQL
-CREATE EXTERNAL TABLE artists (
-    id      BIGINT,
-    name    STRING,
-    links   STRUCT<url:STRING, picture:STRING>)
+```sql
+CREATE EXTERNAL TABLE people (
+    name STRING,
+    age  INT)
 STORED BY 'org.opensearch.hadoop.hive.OpenSearchStorageHandler'
 TBLPROPERTIES(
     'opensearch.nodes' = 'https://search-xxx.us-east-1.es.amazonaws.com',
     'opensearch.port' = '443',
     'opensearch.net.ssl' = 'true',
-    'opensearch.resource' = 'artists',
+    'opensearch.resource' = 'people',
     'opensearch.nodes.wan.only' = 'true',
     'opensearch.aws.sigv4.enabled' = 'true',
-    'opensearch.aws.sigv4.region' = 'us-east-1'
-    );
+    'opensearch.aws.sigv4.region' = 'us-east-1');
 ```
-
-## [Apache Spark][]
-
-OpenSearch-Hadoop provides native (Java and Scala) integration with Spark: for reading a dedicated `RDD` and for writing, methods that work on any `RDD`. Spark SQL is also supported
-
-### Scala
-
-### Reading
-
-To read data from OpenSearch, create a dedicated `RDD` and specify the query as an argument:
-
-```scala
-import org.opensearch.spark._
-
-..
-val conf = ...
-val sc = new SparkContext(conf)
-sc.opensearchRDD("radio/artists", "?q=me*")
-```
-
-#### Spark SQL
-
-```scala
-import org.opensearch.spark.sql._
-
-// DataFrame schema automatically inferred
-val df = sqlContext.read.format("opensearch").load("buckethead/albums")
-
-// operations get pushed down and translated at runtime to OpenSearch QueryDSL
-val playlist = df.filter(df("category").equalTo("pikes").and(df("year").geq(2016)))
-```
-
-### Writing
-
-Import the `org.opensearch.spark._` package to gain `savetoOpenSearch` methods on your `RDD`s:
-
-```scala
-import org.opensearch.spark._
-
-val conf = ...
-val sc = new SparkContext(conf)
-
-val numbers = Map("one" -> 1, "two" -> 2, "three" -> 3)
-val airports = Map("OTP" -> "Otopeni", "SFO" -> "San Fran")
-
-sc.makeRDD(Seq(numbers, airports)).saveToOpenSearch("spark/docs")
-```
-
-#### Spark SQL
-
-```scala
-import org.opensearch.spark.sql._
-
-val df = sqlContext.read.json("examples/people.json")
-df.saveToOpenSearch("spark/people")
-```
-
-### Java
-
-In a Java environment, use the `org.opensearch.spark.rdd.java.api` package, in particular the `JavaOpenSearchSpark` class.
-
-### Reading
-
-To read data from OpenSearch, create a dedicated `RDD` and specify the query as an argument.
-
-```java
-import org.apache.spark.api.java.JavaSparkContext;
-import org.opensearch.spark.rdd.api.java.JavaOpenSearchSpark;
-
-SparkConf conf = ...
-JavaSparkContext jsc = new JavaSparkContext(conf);
-
-JavaPairRDD<String, Map<String, Object>> opensearchRDD = JavaOpenSearchSpark.opensearchRDD(jsc, "radio/artists");
-```
-
-#### Spark SQL
-
-```java
-SQLContext sql = new SQLContext(sc);
-DataFrame df = sql.read().format("opensearch").load("buckethead/albums");
-DataFrame playlist = df.filter(df.col("category").equalTo("pikes").and(df.col("year").geq(2016)))
-```
-
-### Writing
-
-Use `JavaOpenSearchSpark` to index any `RDD` to OpenSearch:
-
-```java
-import org.opensearch.spark.rdd.api.java.JavaOpenSearchSpark;
-
-SparkConf conf = ...
-JavaSparkContext jsc = new JavaSparkContext(conf);
-
-Map<String, ?> numbers = ImmutableMap.of("one", 1, "two", 2);
-Map<String, ?> airports = ImmutableMap.of("OTP", "Otopeni", "SFO", "San Fran");
-
-JavaRDD<Map<String, ?>> javaRDD = jsc.parallelize(ImmutableList.of(numbers, airports));
-JavaOpenSearchSpark.saveToOpenSearch(javaRDD, "spark/docs");
-```
-
-#### Spark SQL
-
-```java
-import org.opensearch.spark.sql.api.java.JavaOpenSearchSparkSQL;
-
-DataFrame df = sqlContext.read.json("examples/people.json")
-JavaOpenSearchSparkSQL.saveToOpenSearch(df, "spark/docs")
-```
-
-### Signing requests for IAM authentication
-
-Signing requests would require the [aws-sdk-bundle](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-bundle) in your job classpath.
-
-```scala
-import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.SQLContext._
-import org.opensearch.spark.sql._
-
-val sql = new SQLContext(sc)
-
-val accountsRead = sql.read.json("/Users/user/release/maximus/data/accounts.json")
-
-val options = Map("pushdown" -> "true",
-"opensearch.nodes" -> "https://aos-2.3-domain",
-"opensearch.aws.sigv4.enabled" -> "true",
-"opensearch.aws.sigv4.region" -> "us-west-2",
-"opensearch.nodes.resolve.hostname" -> "false",
-"opensearch.nodes.wan.only" -> "true",
-"opensearch.net.ssl" -> "true")
-accountsRead.saveToOpenSearch("accounts-00001", options)
-```
-[Map/Reduce]: http://hadoop.apache.org/docs/r1.2.1/mapred_tutorial.html
-[Apache Hive]: http://hive.apache.org
-[Apache Spark]: http://spark.apache.org
-[HiveQL]: http://cwiki.apache.org/confluence/display/Hive/LanguageManual
-[external table]: http://cwiki.apache.org/Hive/external-tables.html
-[DistributedCache]: http://hadoop.apache.org/docs/stable/api/org/apache/hadoop/filecache/DistributedCache.html


### PR DESCRIPTION
### Description

Restructure and expand the documentation to make it easier for new users to get started.

**README.md**
- Add project overview with use cases
- Add PySpark quick start example with `--packages`
- Add Maven coordinates table for all Spark/Scala variants
- Simplify requirements and building sections
- Link to User Guide for Amazon OpenSearch Service and Serverless

**USER_GUIDE.md**
- Reorganize by language (PySpark, Scala, Java) so each section is self-contained
- Add PySpark examples for writing, reading, and querying
- Add Common Patterns section: document ID, write modes, upsert, query pushdown, field selection, scroll size, dynamic index routing, and more
- Add dedicated sections for Amazon OpenSearch Service and Amazon OpenSearch Serverless with copy-paste ready examples
- Move Map/Reduce and Hive to the end

**COMPATIBILITY.md**
- Add Java compatibility table
- Update for v2.0.0 (OpenSearch 3.x, Spark 3.5, Spark 4.x)

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-hadoop/issues/365
Closes https://github.com/opensearch-project/opensearch-hadoop/issues/182

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).