### PR TITLE
Allow skipping version conflict check via system property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Added
+- Add system property `opensearch.hadoop.version.check.skip` to bypass multiple JAR version detection ([#753](https://github.com/opensearch-project/opensearch-hadoop/pull/753))
+
 ### Dependencies
 - Bumps `commons-logging:commons-logging` from 1.3.5 to 1.3.6
 - Bumps `com.fasterxml.jackson.core:jackson-databind` from 2.21.1 to 2.21.3

--- a/mr/src/main/java/org/opensearch/hadoop/util/Version.java
+++ b/mr/src/main/java/org/opensearch/hadoop/util/Version.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.logging.LogFactory;
+import org.opensearch.hadoop.util.unit.Booleans;
 
 
 public abstract class Version {
@@ -104,7 +105,7 @@ public abstract class Version {
                         sb.append("\n");
                     }
                 }
-                if (foundJars > 1 && !"true".equals(System.getProperty("opensearch.hadoop.version.check.skip"))) {
+                if (foundJars > 1 && !Booleans.parseBoolean(System.getProperty("opensearch.hadoop.version.check.skip"))) {
                     throw new RuntimeException(sb.toString());
                 }
             }

--- a/mr/src/main/java/org/opensearch/hadoop/util/Version.java
+++ b/mr/src/main/java/org/opensearch/hadoop/util/Version.java
@@ -104,7 +104,7 @@ public abstract class Version {
                         sb.append("\n");
                     }
                 }
-                if (foundJars > 1) {
+                if (foundJars > 1 && !"true".equals(System.getProperty("opensearch.hadoop.version.check.skip"))) {
                     throw new RuntimeException(sb.toString());
                 }
             }


### PR DESCRIPTION
### Description
Add support for a JVM system property `opensearch.hadoop.version.check.skip` that, when set to `"true"`, skips the multiple JAR detection in `Version.java`. This allows users on managed Spark platforms (e.g. AWS Glue) to use a newer version of opensearch-hadoop alongside a platform-bundled older version that cannot be removed from the classpath.

Usage: `-Dopensearch.hadoop.version.check.skip=true`

### Issues Resolved
Closes #752 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
