### PR TITLE
Add explicit workflow permissions for org-level read-only GITHUB_TOKEN default

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   apply-label:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
       - name: Delete merged branch

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -9,6 +9,9 @@ jobs:
   draft-a-release:
     name: Draft a release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
### Description
The org-level default permission for `GITHUB_TOKEN` has been changed to read-only. Workflows that require write access must now explicitly declare `permissions:` blocks, otherwise they will fail with permission errors.

This PR adds explicit permissions to three workflows that require write access.

- `add-untriaged.yml`: `issues: write` (adding labels to issues)
- `delete_backport_branch.yml`: `contents: write` (deleting merged backport branches)
- `release_drafter.yml`: `contents: write` (creating release drafts), `issues: write` (creating approval issues)

### Issues Resolved
N/A (operational fix in response to org-level security policy change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
