### PR TITLE
Bump commons-codec:commons-codec from 1.21.0 to 1.22.0 in /buildSrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `software.amazon.awssdk:auth` from 2.34.5 to 2.42.0
 - Bumps `software.amazon.awssdk:utils` from 2.38.2 to 2.42.4
 - Bumps `software.amazon.awssdk:http-client-spi` from 2.39.6 to 2.40.3
+- Bumps `commons-codec:commons-codec` from 1.21.0 to 1.22.0 ([#774](https://github.com/opensearch-project/opensearch-hadoop/pull/774))
 
 ## [1.3.0]
 ### Added

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 
     // Required for dependency licenses task
     implementation 'org.apache.rat:apache-rat:0.15'
-    implementation 'commons-codec:commons-codec:1.21.0'
+    implementation 'commons-codec:commons-codec:1.22.0'
 
     if (localRepo) {
         implementation(name: "build-tools-${buildToolsVersion}") {


### PR DESCRIPTION
### Description

Bumps commons-codec:commons-codec from 1.21.0 to 1.22.0 in /buildSrc.

Replaces #756 (dependabot branch is no longer pushable due to org-level ruleset changes).

This is a temporary workaround. The org-level `global_dependabot` ruleset now blocks pushes to `dependabot/**` branches, and the GitHub App private key used by `dependabot_pr.yml` has been retired per the admin team's new security policy. As a result, the automated `updateSHAs` + CHANGELOG workflow no longer functions. Until a permanent solution is established (e.g. automating this via `pull_request_target` with ruleset bypass, or replacing Dependabot entirely), dependency bumps will be handled manually like this PR.

### Issues Resolved

N/A (dependency version update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).