### PR TITLE
Bump org.slf4j:slf4j-api from 2.0.17 to 2.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `software.amazon.awssdk:auth` from 2.34.5 to 2.42.0
 - Bumps `software.amazon.awssdk:utils` from 2.38.2 to 2.42.4
 - Bumps `software.amazon.awssdk:http-client-spi` from 2.39.6 to 2.40.3
+- Bumps `org.slf4j:slf4j-api` from 2.0.17 to 2.0.18 ([#776](https://github.com/opensearch-project/opensearch-hadoop/pull/776))
 
 ## [1.3.0]
 ### Added

--- a/spark/core/build.gradle
+++ b/spark/core/build.gradle
@@ -63,7 +63,7 @@ sparkVariants {
             add(variant.configuration('compileOnly'), "com.fasterxml.jackson.core:jackson-annotations:2.21")
             add(variant.configuration('compileOnly'), "com.google.guava:guava:23.0")
             add(variant.configuration('compileOnly'), "com.google.protobuf:protobuf-java:4.34.1")
-            add(variant.configuration('compileOnly'), "org.slf4j:slf4j-api:2.0.17")
+            add(variant.configuration('compileOnly'), "org.slf4j:slf4j-api:2.0.18")
 
             add(variant.configuration('test', 'implementation'), project(":test:shared"))
             add(variant.configuration('test', 'implementation'), "com.esotericsoftware.kryo:kryo:2.24.0")

--- a/spark/sql-30/build.gradle
+++ b/spark/sql-30/build.gradle
@@ -65,7 +65,7 @@ sparkVariants {
             add(variant.configuration('implementation'), "org.apache.spark:spark-streaming_${variant.scalaMajorVersion}:$variant.sparkVersion") {
                 exclude group: 'org.apache.hadoop'
             }
-            add(variant.configuration('implementation'), "org.slf4j:slf4j-api:2.0.17") {
+            add(variant.configuration('implementation'), "org.slf4j:slf4j-api:2.0.18") {
                 because 'spark exposes slf4j components in traits that we need to extend'
             }
             add(variant.configuration('implementation'), "commons-logging:commons-logging:1.3.6")

--- a/spark/sql-35/build.gradle
+++ b/spark/sql-35/build.gradle
@@ -68,7 +68,7 @@ sparkVariants {
             add(variant.configuration('implementation'), "org.apache.spark:spark-streaming_${variant.scalaMajorVersion}:$variant.sparkVersion") {
                 exclude group: 'org.apache.hadoop'
             }
-            add(variant.configuration('implementation'), "org.slf4j:slf4j-api:2.0.17") {
+            add(variant.configuration('implementation'), "org.slf4j:slf4j-api:2.0.18") {
                 because 'spark exposes slf4j components in traits that we need to extend'
             }
             add(variant.configuration('implementation'), "commons-logging:commons-logging:1.3.6")

--- a/spark/sql-40/build.gradle
+++ b/spark/sql-40/build.gradle
@@ -78,7 +78,7 @@ sparkVariants {
             add(variant.configuration('implementation'), "org.apache.spark:spark-streaming_${variant.scalaMajorVersion}:$variant.sparkVersion") {
                 exclude group: 'org.apache.hadoop'
             }
-            add(variant.configuration('implementation'), "org.slf4j:slf4j-api:2.0.17") {
+            add(variant.configuration('implementation'), "org.slf4j:slf4j-api:2.0.18") {
                 because 'spark exposes slf4j components in traits that we need to extend'
             }
             add(variant.configuration('implementation'), "commons-logging:commons-logging:1.3.6")


### PR DESCRIPTION
### Description

Bumps org.slf4j:slf4j-api from 2.0.17 to 2.0.18 in spark/core, spark/sql-30, spark/sql-35, and spark/sql-40.

Replaces #766, #769, #770 (dependabot branches are no longer pushable due to org-level ruleset changes).

This is a temporary workaround. The org-level `global_dependabot` ruleset now blocks pushes to `dependabot/**` branches, and the GitHub App private key used by `dependabot_pr.yml` has been retired per the admin team's new security policy. As a result, the automated `updateSHAs` + CHANGELOG workflow no longer functions. Until a permanent solution is established, dependency bumps will be handled manually like this PR.

### Issues Resolved

N/A (dependency version update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).