### PR TITLE
Bump com.fasterxml.jackson.core:jackson-databind from 2.21.1 to 2.21.4 in /hive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `software.amazon.awssdk:auth` from 2.34.5 to 2.42.0
 - Bumps `software.amazon.awssdk:utils` from 2.38.2 to 2.42.4
 - Bumps `software.amazon.awssdk:http-client-spi` from 2.39.6 to 2.40.3
+- Bumps `com.fasterxml.jackson.core:jackson-databind` from 2.21.1 to 2.21.4 ([#778](https://github.com/opensearch-project/opensearch-hadoop/pull/778))
 
 ## [1.3.0]
 ### Added

--- a/hive/build.gradle
+++ b/hive/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation("org.apache.hive:hive-jdbc:$hiveVersion") {
         exclude module: "log4j-slf4j-impl"
     }
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.21.3")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.21.4")
 
     itestImplementation(project(":test:shared"))
     itestImplementation("org.apache.hive:hive-service:$hiveVersion") {
@@ -52,7 +52,7 @@ dependencies {
         exclude module: "log4j-slf4j-impl"
     }
     itestImplementation("org.apache.tez:tez-dag:0.9.2")
-    itestImplementation("com.fasterxml.jackson.core:jackson-databind:2.21.3")
+    itestImplementation("com.fasterxml.jackson.core:jackson-databind:2.21.4")
 
     additionalSources(project(":opensearch-hadoop-mr"))
     javadocSources(project(":opensearch-hadoop-mr"))


### PR DESCRIPTION
### Description

Bumps com.fasterxml.jackson.core:jackson-databind from 2.21.1 to 2.21.4 in /hive.

Replaces #767 (dependabot branch is no longer pushable due to org-level ruleset changes).

This is a temporary workaround. The org-level `global_dependabot` ruleset now blocks pushes to `dependabot/**` branches, and the GitHub App private key used by `dependabot_pr.yml` has been retired per the admin team's new security policy. As a result, the automated `updateSHAs` + CHANGELOG workflow no longer functions. Until a permanent solution is established, dependency bumps will be handled manually like this PR.

### Issues Resolved

N/A (dependency version update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).