### PR TITLE
Bump io.netty:netty-all from 4.0.56.Final to 4.2.15.Final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumps `software.amazon.awssdk:auth` from 2.34.5 to 2.42.0
 - Bumps `software.amazon.awssdk:utils` from 2.38.2 to 2.42.4
 - Bumps `software.amazon.awssdk:http-client-spi` from 2.39.6 to 2.40.3
+- Bumps `io.netty:netty-all` from 4.2.10.Final to 4.2.15.Final ([#780](https://github.com/opensearch-project/opensearch-hadoop/pull/780))
 
 ## [1.3.0]
 ### Added

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
     testImplementation(project(":test:shared"))
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.21.3")
-    testImplementation("io.netty:netty-all:4.2.10.Final")
+    testImplementation("io.netty:netty-all:4.2.15.Final")
     testImplementation("org.elasticsearch:securemock:1.2")
 
     itestEmbedded(project(":test:shared"))

--- a/test/shared/build.gradle
+++ b/test/shared/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 
     implementation("org.hamcrest:hamcrest-all:${project.ext.hamcrestVersion}")
 
-    implementation("io.netty:netty-all:4.0.56.Final") {
+    implementation("io.netty:netty-all:4.2.15.Final") {
         because "Needed for creating mock SSL Server to test against"
     }
 


### PR DESCRIPTION
### Description

Bumps io.netty:netty-all from 4.0.56.Final to 4.2.15.Final in /test/shared, and from 4.2.10.Final to 4.2.15.Final in /mr.

Replaces #773 (dependabot branch is no longer pushable due to org-level ruleset changes).

This is a temporary workaround. The org-level `global_dependabot` ruleset now blocks pushes to `dependabot/**` branches, and the GitHub App private key used by `dependabot_pr.yml` has been retired per the admin team's new security policy. As a result, the automated `updateSHAs` + CHANGELOG workflow no longer functions. Until a permanent solution is established, dependency bumps will be handled manually like this PR.

### Issues Resolved

N/A (dependency version update)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).