### PR TITLE
Fix SNI not being set on SSLSocket when using connect timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed RowSerializationEventConverterTest for Spark 3.4+ StructType.toString() format change ([#702](https://github.com/opensearch-project/opensearch-hadoop/pull/702))
 - Fixed object fields with `enabled: false` returning empty structs or throwing exceptions when read via the connector ([#715](https://github.com/opensearch-project/opensearch-hadoop/pull/715))
 - Fixed SigV4 signing failure on bulk retry after partial success causing `x-amz-content-sha256 invalid` ([#759](https://github.com/opensearch-project/opensearch-hadoop/pull/759))
+- Fixed SNI not being set on SSLSocket when using connect timeout, causing TLS handshake failures under BCJSSE ([#781](https://github.com/opensearch-project/opensearch-hadoop/pull/781))
 
 ### Security
 

--- a/mr/src/main/java/org/opensearch/hadoop/rest/commonshttp/SSLSocketFactory.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/commonshttp/SSLSocketFactory.java
@@ -41,10 +41,15 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
+import java.util.Collections;
+
 import javax.net.SocketFactory;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
@@ -142,6 +147,12 @@ class SSLSocketFactory implements SecureProtocolSocketFactory {
         }
         else {
             Socket socket = socketfactory.createSocket();
+            if (socket instanceof SSLSocket) {
+                SSLSocket sslSocket = (SSLSocket) socket;
+                SSLParameters sslParams = sslSocket.getSSLParameters();
+                sslParams.setServerNames(Collections.singletonList(new SNIHostName(host)));
+                sslSocket.setSSLParameters(sslParams);
+            }
             SocketAddress localaddr = new InetSocketAddress(localAddress, localPort);
             SocketAddress remoteaddr = new InetSocketAddress(host, port);
             socket.bind(localaddr);


### PR DESCRIPTION
### Description
Under BCJSSE (Bouncy Castle JSSE provider), creating an unconnected SSLSocket via `createSocket()` and then calling `connect(InetSocketAddress, timeout)` does not automatically propagate the hostname for SNI on the TLS ClientHello. This causes TLS handshake failures against endpoints that require SNI for certificate selection (e.g. AWS OpenSearch managed domains behind load balancers).

The standard SunJSSE provider happens to infer SNI from the `InetSocketAddress` hostname, but this is an implementation detail and not guaranteed by the JSSE specification.

The fix explicitly sets SNI server names via `SSLParameters.setServerNames()` before connecting. This works correctly with both SunJSSE and BCJSSE, and does not affect timeout behavior.

Verified locally with Bouncy Castle JSSE 1.80 that the handshake succeeds after this change.

### Issues Resolved
Closes #765

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).