### PR TITLE
Enable parallel reads for OpenSearch Serverless via PIT + Slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add Apache Spark 4.0 support ([#684](https://github.com/opensearch-project/opensearch-hadoop/pull/684))
 - Add dedicated `opensearch.search_after.size` setting for serverless mode page size ([#695](https://github.com/opensearch-project/opensearch-hadoop/pull/695))
 - Add Apache Spark 3.5 support with dedicated opensearch-spark-35 module ([#717](https://github.com/opensearch-project/opensearch-hadoop/pull/717))
+- Add parallel read support for next-generation OpenSearch Serverless via PIT + Slice ([#783](https://github.com/opensearch-project/opensearch-hadoop/pull/783))
 
 ### Changed
 - Switched to more reliable OpenSearch Lucene snapshot location ([#597](https://github.com/opensearch-project/opensearch-hadoop/pull/597))

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -392,6 +392,28 @@ df = spark.read.format("opensearch") \
     .load("my-index")
 ```
 
+### Parallel Reads
+
+Serverless mode automatically splits reads into parallel partitions using PIT + Slice. By default, the connector creates one partition per 50,000 documents in each index.
+
+To customize the partition size, set `opensearch.input.max.docs.per.partition`:
+
+```python
+df = spark.read.format("opensearch") \
+    .option("opensearch.nodes", "https://xxx.us-east-1.aoss.amazonaws.com") \
+    .option("opensearch.port", "443") \
+    .option("opensearch.net.ssl", "true") \
+    .option("opensearch.nodes.wan.only", "true") \
+    .option("opensearch.aws.sigv4.enabled", "true") \
+    .option("opensearch.aws.sigv4.region", "us-east-1") \
+    .option("opensearch.aws.sigv4.service.name", "aoss") \
+    .option("opensearch.serverless", "true") \
+    .option("opensearch.input.max.docs.per.partition", "100000") \
+    .load("my-index")
+```
+
+The connector will count the documents in each index, divide by this value to determine the number of slices, and create one Spark partition per slice. For example, an index with 1,000,000 documents and `max.docs.per.partition=100000` will produce 10 parallel read tasks.
+
 ## Map/Reduce
 
 For low-level Hadoop Map/Reduce jobs, opensearch-hadoop provides `OpenSearchInputFormat` and `OpenSearchOutputFormat`. Add `opensearch-hadoop-mr-2.0.0.jar` to your job classpath.
@@ -472,31 +494,3 @@ TBLPROPERTIES(
     'opensearch.aws.sigv4.region' = 'us-east-1');
 ```
 
-## Amazon OpenSearch Serverless
-
-The connector supports Amazon OpenSearch Serverless (both Classic and NextGen architectures). Serverless collections do not expose shard information, so the connector uses PIT (Point in Time) with search_after for pagination instead of the scroll API.
-
-### Basic Configuration
-
-```
-opensearch.serverless=true
-opensearch.nodes=https://<collection-id>.aoss.<region>.on.aws
-opensearch.port=443
-opensearch.net.ssl=true
-opensearch.nodes.wan.only=true
-opensearch.aws.sigv4.enabled=true
-opensearch.aws.sigv4.region=<region>
-opensearch.aws.sigv4.service.name=aoss
-```
-
-### Parallel Reads
-
-Serverless mode automatically splits reads into parallel partitions using PIT + Slice. By default, the connector creates one partition per 50,000 documents in each index.
-
-To customize the partition size, set `opensearch.input.max.docs.per.partition`:
-
-```
-opensearch.input.max.docs.per.partition=100000
-```
-
-The connector will count the documents in each index, divide by this value to determine the number of slices, and create one Spark partition per slice. For example, an index with 1,000,000 documents and `max.docs.per.partition=100000` will produce 10 parallel read tasks.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -471,3 +471,34 @@ TBLPROPERTIES(
     'opensearch.aws.sigv4.enabled' = 'true',
     'opensearch.aws.sigv4.region' = 'us-east-1');
 ```
+
+## Amazon OpenSearch Serverless
+
+The connector supports Amazon OpenSearch Serverless (both Classic and NextGen architectures). Serverless collections do not expose shard information, so the connector uses PIT (Point in Time) with search_after for pagination instead of the scroll API.
+
+### Basic Configuration
+
+```
+opensearch.serverless=true
+opensearch.nodes=https://<collection-id>.aoss.<region>.on.aws
+opensearch.port=443
+opensearch.net.ssl=true
+opensearch.nodes.wan.only=true
+opensearch.aws.sigv4.enabled=true
+opensearch.aws.sigv4.region=<region>
+opensearch.aws.sigv4.service.name=aoss
+```
+
+### Parallel Reads (NextGen Only)
+
+By default, serverless mode reads each index serially in a single partition. The next-generation OpenSearch Serverless architecture supports PIT with sliced search, which enables parallel reads across multiple Spark tasks.
+
+To enable parallel reads, set `opensearch.input.max.docs.per.partition`:
+
+```
+opensearch.input.max.docs.per.partition=100000
+```
+
+The connector will count the documents in each index, divide by this value to determine the number of slices, and create one Spark partition per slice. For example, an index with 1,000,000 documents and `max.docs.per.partition=100000` will produce 10 parallel read tasks.
+
+This setting requires the next-generation OpenSearch Serverless architecture. Using it with Classic Serverless collections will result in a server-side error because Classic does not support the Slice API.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -489,16 +489,14 @@ opensearch.aws.sigv4.region=<region>
 opensearch.aws.sigv4.service.name=aoss
 ```
 
-### Parallel Reads (NextGen Only)
+### Parallel Reads
 
-By default, serverless mode reads each index serially in a single partition. The next-generation OpenSearch Serverless architecture supports PIT with sliced search, which enables parallel reads across multiple Spark tasks.
+Serverless mode automatically splits reads into parallel partitions using PIT + Slice. By default, the connector creates one partition per 50,000 documents in each index.
 
-To enable parallel reads, set `opensearch.input.max.docs.per.partition`:
+To customize the partition size, set `opensearch.input.max.docs.per.partition`:
 
 ```
 opensearch.input.max.docs.per.partition=100000
 ```
 
 The connector will count the documents in each index, divide by this value to determine the number of slices, and create one Spark partition per slice. For example, an index with 1,000,000 documents and `max.docs.per.partition=100000` will produce 10 parallel read tasks.
-
-This setting requires the next-generation OpenSearch Serverless architecture. Using it with Classic Serverless collections will result in a server-side error because Classic does not support the Slice API.

--- a/mr/src/main/java/org/opensearch/hadoop/cfg/ConfigurationOptions.java
+++ b/mr/src/main/java/org/opensearch/hadoop/cfg/ConfigurationOptions.java
@@ -164,6 +164,7 @@ public interface ConfigurationOptions {
 
     /** Input options **/
     String OPENSEARCH_MAX_DOCS_PER_PARTITION = "opensearch.input.max.docs.per.partition";
+    String OPENSEARCH_MAX_DOCS_PER_PARTITION_SERVERLESS_DEFAULT = "50000";
 
     String OPENSEARCH_INPUT_JSON = "opensearch.input.json";
     String OPENSEARCH_INPUT_JSON_DEFAULT = "no";

--- a/mr/src/main/java/org/opensearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/RestService.java
@@ -229,15 +229,11 @@ public abstract class RestService implements Serializable {
 
     /**
      * Create partitions for OpenSearch Serverless mode, which doesn't support shard APIs.
-     * This function creates a single partition for each index as serverless doesn't expose shard information.
+     * When maxDocsPerPartition is set, creates multiple sliced partitions per index for parallel reads.
+     * This requires PIT + Slice support (available on next-generation OpenSearch Serverless).
+     * On Classic Serverless, using maxDocsPerPartition will result in a server-side error.
      */
     static List<PartitionDefinition> findServerlessPartitions(RestRepository client, Settings settings, MappingSet mappingSet, Log log) {
-        if (settings.getMaxDocsPerPartition() != null) {
-            throw new OpenSearchHadoopIllegalArgumentException(
-                "maxDocsPerPartition setting is not supported in OpenSearch Serverless mode. " +
-                "Serverless does not support Slice API which is required for parallel partition reads.");
-        }
-
         Resource readResource = new Resource(settings, true);
         Mapping resolvedMapping = mappingSet == null ? null : mappingSet.getResolvedView();
         PartitionDefinition.PartitionDefinitionBuilder partitionBuilder = PartitionDefinition.builder(settings, resolvedMapping);
@@ -247,9 +243,22 @@ public abstract class RestService implements Serializable {
         List<PartitionDefinition> partitions = new ArrayList<PartitionDefinition>();
         String[] indices = readResource.index().split(",");
 
+        Integer maxDocsPerPartition = settings.getMaxDocsPerPartition();
+
         for (String indexName : indices) {
             indexName = indexName.trim();
-            partitions.add(partitionBuilder.build(indexName, 0, new String[0]));
+            if (maxDocsPerPartition != null) {
+                QueryBuilder query = QueryUtils.parseQueryAndFilters(settings);
+                long numDocs = client.getRestClient().count(indexName, query);
+                int numPartitions = (int) Math.max(1, numDocs / maxDocsPerPartition);
+                log.info(String.format("Serverless parallel read: index [%s] has [%d] docs, creating [%d] sliced partitions", indexName, numDocs, numPartitions));
+                for (int i = 0; i < numPartitions; i++) {
+                    PartitionDefinition.Slice slice = new PartitionDefinition.Slice(i, numPartitions);
+                    partitions.add(partitionBuilder.build(indexName, 0, slice, new String[0]));
+                }
+            } else {
+                partitions.add(partitionBuilder.build(indexName, 0, new String[0]));
+            }
         }
 
         return partitions;

--- a/mr/src/main/java/org/opensearch/hadoop/rest/RestService.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/RestService.java
@@ -229,9 +229,8 @@ public abstract class RestService implements Serializable {
 
     /**
      * Create partitions for OpenSearch Serverless mode, which doesn't support shard APIs.
-     * When maxDocsPerPartition is set, creates multiple sliced partitions per index for parallel reads.
-     * This requires PIT + Slice support (available on next-generation OpenSearch Serverless).
-     * On Classic Serverless, using maxDocsPerPartition will result in a server-side error.
+     * When maxDocsPerPartition is set, creates multiple sliced partitions per index for parallel reads
+     * using PIT + Slice.
      */
     static List<PartitionDefinition> findServerlessPartitions(RestRepository client, Settings settings, MappingSet mappingSet, Log log) {
         Resource readResource = new Resource(settings, true);
@@ -244,13 +243,16 @@ public abstract class RestService implements Serializable {
         String[] indices = readResource.index().split(",");
 
         Integer maxDocsPerPartition = settings.getMaxDocsPerPartition();
+        if (maxDocsPerPartition == null) {
+            maxDocsPerPartition = Integer.parseInt(ConfigurationOptions.OPENSEARCH_MAX_DOCS_PER_PARTITION_SERVERLESS_DEFAULT);
+        }
 
         for (String indexName : indices) {
             indexName = indexName.trim();
-            if (maxDocsPerPartition != null) {
-                QueryBuilder query = QueryUtils.parseQueryAndFilters(settings);
-                long numDocs = client.getRestClient().count(indexName, query);
-                int numPartitions = (int) Math.max(1, numDocs / maxDocsPerPartition);
+            QueryBuilder query = QueryUtils.parseQueryAndFilters(settings);
+            long numDocs = client.getRestClient().count(indexName, query);
+            int numPartitions = (int) Math.max(1, numDocs / maxDocsPerPartition);
+            if (numPartitions > 1) {
                 log.info(String.format("Serverless parallel read: index [%s] has [%d] docs, creating [%d] sliced partitions", indexName, numDocs, numPartitions));
                 for (int i = 0; i < numPartitions; i++) {
                     PartitionDefinition.Slice slice = new PartitionDefinition.Slice(i, numPartitions);

--- a/mr/src/main/java/org/opensearch/hadoop/rest/SearchRequestBuilder.java
+++ b/mr/src/main/java/org/opensearch/hadoop/rest/SearchRequestBuilder.java
@@ -377,6 +377,15 @@ public class SearchRequestBuilder {
         JacksonJsonGenerator generator = new JacksonJsonGenerator(out);
         try {
             generator.writeBeginObject();
+            if (slice != null && slice.max > 1) {
+                generator.writeFieldName("slice");
+                generator.writeBeginObject();
+                generator.writeFieldName("id");
+                generator.writeNumber(slice.id);
+                generator.writeFieldName("max");
+                generator.writeNumber(slice.max);
+                generator.writeEndObject();
+            }
             generator.writeFieldName("query");
             generator.writeBeginObject();
             root.toJson(generator);

--- a/mr/src/test/java/org/opensearch/hadoop/rest/ServerlessModeTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/rest/ServerlessModeTest.java
@@ -14,7 +14,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.impl.NoOpLog;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.opensearch.hadoop.OpenSearchHadoopIllegalArgumentException;
 import org.opensearch.hadoop.cfg.ConfigurationOptions;
 import org.opensearch.hadoop.cfg.PropertiesSettings;
 import org.opensearch.hadoop.cfg.Settings;
@@ -79,14 +78,54 @@ public class ServerlessModeTest {
         assertEquals("index3", partitions.get(2).getIndex());
     }
 
-    @Test(expected = OpenSearchHadoopIllegalArgumentException.class)
-    public void testFindServerlessPartitionsRejectsMaxDocsPerPartition() {
+    @Test
+    public void testFindServerlessPartitionsWithMaxDocsPerPartition() {
         Settings settings = new PropertiesSettings();
         settings.setProperty(ConfigurationOptions.OPENSEARCH_RESOURCE_READ, "test-index");
         settings.setServerlessMode(true);
+        settings.setMaxDocsPerPartition(500);
+
+        RestClient restClient = Mockito.mock(RestClient.class);
+        Mockito.when(restClient.count(Mockito.eq("test-index"), Mockito.any()))
+                .thenReturn(2000L);
+
+        RestRepository repository = Mockito.mock(RestRepository.class);
+        Mockito.when(repository.getRestClient()).thenReturn(restClient);
+
+        List<PartitionDefinition> partitions = RestService.findServerlessPartitions(repository, settings, null, LOGGER);
+
+        assertEquals(4, partitions.size());
+        for (int i = 0; i < 4; i++) {
+            assertEquals("test-index", partitions.get(i).getIndex());
+            assertNotNull(partitions.get(i).getSlice());
+            assertEquals(i, partitions.get(i).getSlice().id);
+            assertEquals(4, partitions.get(i).getSlice().max);
+        }
+    }
+
+    @Test
+    public void testFindServerlessPartitionsWithMaxDocsPerPartitionMultipleIndices() {
+        Settings settings = new PropertiesSettings();
+        settings.setProperty(ConfigurationOptions.OPENSEARCH_RESOURCE_READ, "index1,index2");
+        settings.setServerlessMode(true);
         settings.setMaxDocsPerPartition(1000);
 
-        RestService.findServerlessPartitions(null, settings, null, LOGGER);
+        RestClient restClient = Mockito.mock(RestClient.class);
+        Mockito.when(restClient.count(Mockito.eq("index1"), Mockito.any()))
+                .thenReturn(3000L);
+        Mockito.when(restClient.count(Mockito.eq("index2"), Mockito.any()))
+                .thenReturn(1500L);
+
+        RestRepository repository = Mockito.mock(RestRepository.class);
+        Mockito.when(repository.getRestClient()).thenReturn(restClient);
+
+        List<PartitionDefinition> partitions = RestService.findServerlessPartitions(repository, settings, null, LOGGER);
+
+        // index1: 3000/1000 = 3 partitions, index2: 1500/1000 = 1 partition
+        assertEquals(4, partitions.size());
+        assertEquals("index1", partitions.get(0).getIndex());
+        assertEquals("index1", partitions.get(2).getIndex());
+        assertEquals("index2", partitions.get(3).getIndex());
     }
 
     @Test

--- a/mr/src/test/java/org/opensearch/hadoop/rest/ServerlessModeTest.java
+++ b/mr/src/test/java/org/opensearch/hadoop/rest/ServerlessModeTest.java
@@ -57,8 +57,16 @@ public class ServerlessModeTest {
         settings.setProperty(ConfigurationOptions.OPENSEARCH_RESOURCE_READ, "test-index");
         settings.setServerlessMode(true);
 
-        List<PartitionDefinition> partitions = RestService.findServerlessPartitions(null, settings, null, LOGGER);
+        RestClient restClient = Mockito.mock(RestClient.class);
+        Mockito.when(restClient.count(Mockito.eq("test-index"), Mockito.any()))
+                .thenReturn(100L);
 
+        RestRepository repository = Mockito.mock(RestRepository.class);
+        Mockito.when(repository.getRestClient()).thenReturn(restClient);
+
+        List<PartitionDefinition> partitions = RestService.findServerlessPartitions(repository, settings, null, LOGGER);
+
+        // 100 docs / 50000 default = 1 partition (no slicing needed)
         assertEquals(1, partitions.size());
         assertEquals("test-index", partitions.get(0).getIndex());
         assertEquals(0, partitions.get(0).getShardId());
@@ -70,7 +78,14 @@ public class ServerlessModeTest {
         settings.setProperty(ConfigurationOptions.OPENSEARCH_RESOURCE_READ, "index1,index2,index3");
         settings.setServerlessMode(true);
 
-        List<PartitionDefinition> partitions = RestService.findServerlessPartitions(null, settings, null, LOGGER);
+        RestClient restClient = Mockito.mock(RestClient.class);
+        Mockito.when(restClient.count(Mockito.anyString(), Mockito.any()))
+                .thenReturn(100L);
+
+        RestRepository repository = Mockito.mock(RestRepository.class);
+        Mockito.when(repository.getRestClient()).thenReturn(restClient);
+
+        List<PartitionDefinition> partitions = RestService.findServerlessPartitions(repository, settings, null, LOGGER);
 
         assertEquals(3, partitions.size());
         assertEquals("index1", partitions.get(0).getIndex());


### PR DESCRIPTION
### Description
This change enables parallel reads in serverless mode by default using PIT + Slice.

Previously, `opensearch.input.max.docs.per.partition` was rejected in serverless mode with an error stating that Serverless does not support the Slice API. This change removes that validation and introduces a default partition size of 50,000 documents per partition for serverless mode. The connector counts documents in each index and automatically creates multiple sliced partitions, enabling parallel reads across Spark tasks without any additional configuration.

Users can override the default by explicitly setting `opensearch.input.max.docs.per.partition`.

Tested with Spark 4.1 against OpenSearch Serverless collections (both SEARCH and VECTORSEARCH types) in ap-northeast-1. Confirmed correct partition splitting with 10,000 documents, verifying no duplicate or missing records across all partitions.

### Issues Resolved
Closes #782

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).