### PR TITLE
Use actions/create-github-app-token in the Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -18,17 +18,17 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          installation_id: 22958780
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Check out code
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.github_app_token.outputs.token }}
-          
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3


### PR DESCRIPTION
### Description
The Dependabot workflow failed at the GitHub App token step with `A JSON web token could not be decoded`, using the deprecated `tibdex/github-app-token` action. Without a token it could not push the license SHA and changelog updates to the PR branch, which in turn made `verify-changelog` fail. This switches to `actions/create-github-app-token`, matching opensearch-java and opensearch-net.

### Issues Resolved
Closes #799

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).